### PR TITLE
Additional improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,11 +10,34 @@ make -j12
 popd
 ```
 
-### Analysis codee:
+## Analysis code:
 
-Please, refer to `cpp/README.md`.
+For more dedtails, refer to `cpp/README.md`.
 
-### NanoCORE synchronization:
+### Example instructions
+
+Edit `cpp/doAll_Zp.C` with an appropriate file (or hopefully the default one still exists).
+
+```bash
+pushd cpp/
+root -b -q -l -n doAll_Zp.C
+popd
+```
+
+This loops and creates a number of output files of the form `output_"process"_"year".root`, which contains a handful of histograms. 
+
+To produce plots:
+```bash
+python python/stack_plots.py
+```
+
+To produce cutflow table:
+```bash
+python python/make_cutflow_table.py
+```
+
+
+## NanoCORE synchronization:
 
 The `NanoCORE` subdirectory shall be synchronized often with `git@github.com:cmstas/NanoTools.git`.
 For the first time only:
@@ -46,7 +69,7 @@ git push origin <branchname>
 Then, open pull request to `NanoTools` remote repository.
 
 
-### Style:
+## Style:
 
 We use `clang-format` based on LLVM style to format our code. To format the `ElectronSelections.cc` file in-place, do
 ```bash

--- a/README.md
+++ b/README.md
@@ -36,6 +36,19 @@ To produce cutflow table:
 python python/make_cutflow_table.py
 ```
 
+## Pull requests:
+
+When opening a PR against the `main` branch, please make sure your code is up-to-date:
+```bash
+pushd ZPrimeSnt/
+git checkout main
+git pull
+git checkout -b <branchname>
+<Do your developmets and commit>
+git push origin <branchname>
+```
+Then, open a PR against `main` branch and request review.
+
 
 ## NanoCORE synchronization:
 

--- a/cpp/README.md
+++ b/cpp/README.md
@@ -11,13 +11,6 @@ root -b -q -l -n doAll_Zp.C
 ```
 
 This loops and creates a number of output files of the form `output_"process"_"year".root`, which contains a handful of histograms. 
-Currently this script produces 5 output files corresponding to the main backgrounds for this analysis:
-
-`output_DY_2018.root`
-`output_ttbar_2018.root`
-`output_WW_2018.root`
-`output_WZ_2018.root`
-`output_ZZ_2018.root`
 
 ### Making a standalone executable
 

--- a/cpp/ScanChain_Zp.C
+++ b/cpp/ScanChain_Zp.C
@@ -200,7 +200,7 @@ int ScanChain(TChain *ch, double genEventSumw, TString year, TString process) {
       // Number of good primary vertices
       if ( nt.PV_npvsGood() < 1 ) continue;
       h_cutflow->Fill(icutflow,weight*factor);
-      h_cutflow->GetXaxis()->SetBinLabel(icutflow+1,"At least one good PV");
+      h_cutflow->GetXaxis()->SetBinLabel(icutflow+1,">0 good PVs");
       icutflow++;
 
       // Single muon selection loop
@@ -234,7 +234,7 @@ int ScanChain(TChain *ch, double genEventSumw, TString year, TString process) {
 
       if ( !id_req ) continue;
       h_cutflow->Fill(icutflow,weight*factor);
-      h_cutflow->GetXaxis()->SetBinLabel(icutflow+1,"At least two muons w/ highPt ID");
+      h_cutflow->GetXaxis()->SetBinLabel(icutflow+1,">1 muons w/ highPt ID");
       icutflow++;
 
       //Fill histograms before and after these requirements!
@@ -242,7 +242,7 @@ int ScanChain(TChain *ch, double genEventSumw, TString year, TString process) {
       h_mu2_pt_sel1->Fill(nt.Muon_pt().at(cand_muons_pf_id[1]),weight*factor);
       if ( !pt_req ) continue;
       h_cutflow->Fill(icutflow,weight*factor);
-      h_cutflow->GetXaxis()->SetBinLabel(icutflow+1,"At least two muons w/ pT>53 GeV & |eta|<2.4");
+      h_cutflow->GetXaxis()->SetBinLabel(icutflow+1,">1 muons w/ pT>53 GeV & |eta|<2.4");
       icutflow++;
       h_mu1_pt_sel2->Fill(nt.Muon_pt().at(cand_muons_pf_id_and_pteta[0]),weight*factor);
       h_mu2_pt_sel2->Fill(nt.Muon_pt().at(cand_muons_pf_id_and_pteta[1]),weight*factor);
@@ -251,7 +251,7 @@ int ScanChain(TChain *ch, double genEventSumw, TString year, TString process) {
       h_mu2_trkRelIso_sel2->Fill(nt.Muon_tkRelIso().at(cand_muons_pf_id_and_pteta[1]),weight*factor);
       if ( !iso_req ) continue;
       h_cutflow->Fill(icutflow,weight*factor);
-      h_cutflow->GetXaxis()->SetBinLabel(icutflow+1,"At least two muons w/ track iso./pT<0.1");
+      h_cutflow->GetXaxis()->SetBinLabel(icutflow+1,">1 muons w/ track iso./pT<0.1");
       icutflow++;
       h_mu1_trkRelIso_sel3->Fill(nt.Muon_tkRelIso().at(cand_muons_pf[0]),weight*factor);
       h_mu2_trkRelIso_sel3->Fill(nt.Muon_tkRelIso().at(cand_muons_pf[1]),weight*factor);
@@ -277,7 +277,7 @@ int ScanChain(TChain *ch, double genEventSumw, TString year, TString process) {
       }
       if ( !atLeastSelectedMu_matchedToTrigObj ) continue;
       h_cutflow->Fill(icutflow,weight*factor);
-      h_cutflow->GetXaxis()->SetBinLabel(icutflow+1,"At least one HLT match (dR<0.02)");
+      h_cutflow->GetXaxis()->SetBinLabel(icutflow+1,">0 HLT match (dR<0.02)");
       icutflow++;
 
       h_nCand_Muons_sel4->Fill(cand_muons_pf.size(),weight*factor);
@@ -418,7 +418,7 @@ int ScanChain(TChain *ch, double genEventSumw, TString year, TString process) {
       h_mll_pf_sel6->Fill(selectedPair_M,weight*factor);
       if ( cand_bJets.size() < 1 ) continue;
       h_cutflow->Fill(icutflow,weight*factor);
-      h_cutflow->GetXaxis()->SetBinLabel(icutflow+1,"At least one b-tag");
+      h_cutflow->GetXaxis()->SetBinLabel(icutflow+1,">0 b-tag (medium WP)");
       icutflow++;
       h_mll_pf_sel7->Fill(selectedPair_M,weight*factor);
       if ( selectedPair_M < 150 ) continue;

--- a/cpp/ScanChain_Zp.C
+++ b/cpp/ScanChain_Zp.C
@@ -30,6 +30,8 @@
 
 // #define DEBUG
 
+bool removeSpikes = false;
+
 const char* outdir = "temp_data";
 int mdir = mkdir(outdir,0755);
 
@@ -163,7 +165,7 @@ int ScanChain(TChain *ch, double genEventSumw, TString year, TString process) {
       tree->LoadTree(event);
 
       float weight = genWeight();
-      if(weight>1e3) continue;
+      if(removeSpikes && weight*factor>1e2) continue;
 
       int runnb = nt.run();
       int npv = nt.PV_npvs();

--- a/cpp/ScanChain_Zp.C
+++ b/cpp/ScanChain_Zp.C
@@ -26,7 +26,7 @@
 #define COUNT_GT(vec,num) std::count_if((vec).begin(), (vec).end(), [](float x) { return x > (num); });
 #define COUNT_LT(vec,num) std::count_if((vec).begin(), (vec).end(), [](float x) { return x < (num); });
 
-#define H1(name,nbins,low,high) TH1F *h_##name = new TH1F(#name,"",nbins,low,high);
+#define H1(name,nbins,low,high,xtitle) TH1F *h_##name = new TH1F(#name,"",nbins,low,high); h_##name->GetXaxis()->SetTitle(xtitle); h_##name->GetYaxis()->SetTitle("Events");
 
 // #define DEBUG
 
@@ -93,48 +93,44 @@ int ScanChain(TChain *ch, double genEventSumw, TString year, TString process) {
   factor = xsec*lumi/genEventSumw;
 
   // Modify the name of the output file to include arguments of ScanChain function (i.e. process, year, etc.)
-  TFile* f1 = new TFile("temp_data/output_"+process+"_"+year+".root", "RECREATE");
-  H1(cutflow,20,0,20);
-  H1(mll_pf_sel6,241,90,2500);
-  H1(mll_pf_sel7,241,90,2500);
-  H1(mll_pf_sel8,241,90,2500);
-  H1(mll_pf_sel9,241,90,2500);
-  H1(mu1_pt_sel1,200,0,1000);
-  H1(mu2_pt_sel1,200,0,1000);
-  H1(mu1_pt_sel2,200,0,1000);
-  H1(mu2_pt_sel2,200,0,1000);
-  H1(mu1_pt_sel8,200,0,1000);
-  H1(mu2_pt_sel8,200,0,1000);
-  H1(mu1_pt_sel9,200,0,1000);
-  H1(mu2_pt_sel9,200,0,1000);
-  H1(mu1_trkRelIso_sel2,50,0,0.5);
-  H1(mu2_trkRelIso_sel2,50,0,0.5);
-  H1(mu1_trkRelIso_sel3,50,0,0.5);
-  H1(mu2_trkRelIso_sel3,50,0,0.5);
-  H1(mu1_trkRelIso_sel8,50,0,0.1);
-  H1(mu2_trkRelIso_sel8,50,0,0.1);
-  H1(mu1_trkRelIso_sel9,50,0,0.1);
-  H1(mu2_trkRelIso_sel9,50,0,0.1);
-  H1(nCand_Muons_sel4,5,0,5);
-  //H1(btagDeepFlavB_sel6,50,0,1);
-  H1(nbtagDeepFlavB_sel6,5,0,5);
-  H1(bjet1_pt_sel8,200,0,1000);
-  H1(bjet2_pt_sel8,200,0,1000);
-  H1(min_mlb_sel8,200,0,2000);
-  H1(min_mlb_sel9,200,0,2000);
-  H1(met_pt_sel8,120,0,600);
-  H1(met_pt_sel9,120,0,600);
-  H1(met_phi_sel8,65,-3.25,3.25);
-  H1(met_phi_sel9,65,-3.25,3.25);
-  H1(nExtra_muons_sel5,6,0,6);
-  H1(nExtra_electrons_sel5,6,0,6);
-  H1(nExtra_lepIsoTracks_sel5,6,0,6);
-  H1(nExtra_chhIsoTracks_sel5,6,0,6);
-  //H1(third_mu_pt_sel5,100,0,500);
-  //H1(fourth_mu_pt_sel5,100,0,500);
-  //H1(first_el_pt_sel5,100,0,500);
-  //H1(second_el_pt_sel5,100,0,500);
-  //H1(dr_trigobj_sel3,50,0,0.5);
+  TFile* fout = new TFile("temp_data/output_"+process+"_"+year+".root", "RECREATE");
+  H1(cutflow,20,0,20,"");
+  H1(mll_pf_sel6,241,90,2500,"m_{ll} [GeV]");
+  H1(mll_pf_sel7,241,90,2500,"m_{ll} [GeV]");
+  H1(mll_pf_sel8,241,90,2500,"m_{ll} [GeV]");
+  H1(mll_pf_sel9,241,90,2500,"m_{ll} [GeV]");
+  H1(mu1_pt_sel1,200,0,1000,"p_{T} (leading #mu) [GeV]");
+  H1(mu1_pt_sel2,200,0,1000,"p_{T} (leading #mu) [GeV]");
+  H1(mu1_pt_sel8,200,0,1000,"p_{T} (leading #mu) [GeV]");
+  H1(mu1_pt_sel9,200,0,1000,"p_{T} (leading #mu) [GeV]");
+  H1(mu2_pt_sel1,200,0,1000,"p_{T} (subleading #mu) [GeV]");
+  H1(mu2_pt_sel2,200,0,1000,"p_{T} (subleading #mu) [GeV]");
+  H1(mu2_pt_sel8,200,0,1000,"p_{T} (subleading #mu) [GeV]");
+  H1(mu2_pt_sel9,200,0,1000,"p_{T} (subleading #mu) [GeV]");
+  H1(mu1_trkRelIso_sel2,50,0,0.5,"Track iso./p_{T} (leading #mu)");
+  H1(mu1_trkRelIso_sel3,50,0,0.5,"Track iso./p_{T} (leading #mu)");
+  H1(mu1_trkRelIso_sel8,50,0,0.1,"Track iso./p_{T} (leading #mu)");
+  H1(mu1_trkRelIso_sel9,50,0,0.1,"Track iso./p_{T} (leading #mu)");
+  H1(mu2_trkRelIso_sel2,50,0,0.5,"Track iso./p_{T} (subleading #mu)");
+  H1(mu2_trkRelIso_sel3,50,0,0.5,"Track iso./p_{T} (subleading #mu)");
+  H1(mu2_trkRelIso_sel8,50,0,0.1,"Track iso./p_{T} (subleading #mu)");
+  H1(mu2_trkRelIso_sel9,50,0,0.1,"Track iso./p_{T} (subleading #mu)");
+  H1(nCand_Muons_sel4,3,2,5,"Number of #mu candidates");
+  //H1(btagDeepFlavB_sel6,50,0,1,"b-tag deep-flavor discriminant");
+  H1(nbtagDeepFlavB_sel6,5,0,5,"Number of b-tags (medium WP)");
+  H1(bjet1_pt_sel8,200,0,1000,"p_{T} (leading b-tagged jet) [GeV]");
+  H1(bjet2_pt_sel8,200,0,1000,"p_{T} (subleading b-tagged jet) [GeV]");
+  H1(min_mlb_sel8,200,0,2000,"min m_{lb} [GeV]");
+  H1(min_mlb_sel9,200,0,2000,"min m_{lb} [GeV]");
+  H1(met_pt_sel8,120,0,600,"PF MET p_{T} [GeV]");
+  H1(met_pt_sel9,120,0,600,"PF MET p_{T} [GeV]");
+  H1(met_phi_sel8,65,-3.25,3.25,"PF MET #phi");
+  H1(met_phi_sel9,65,-3.25,3.25,"PF MET #phi");
+  H1(nExtra_muons_sel5,6,0,6,"Number of additional #mu's");
+  H1(nExtra_electrons_sel5,6,0,6,"Number of electrons");
+  H1(nExtra_lepIsoTracks_sel5,6,0,6,"Number of (additional) lepton (e/#mu) PF candidates");
+  H1(nExtra_chhIsoTracks_sel5,6,0,6,"Number of (additional) charged hadron PF candidates");
+  H1(dr_trigobj_sel3,50,0,0.5,"min #Delta R (#mu, trigger object)");
 
   int nEventsTotal = 0;
   int nEvents_more_leps = 0;
@@ -157,7 +153,7 @@ int ScanChain(TChain *ch, double genEventSumw, TString year, TString process) {
     // Before any cuts
     int icutflow = 0;
     h_cutflow->Fill(icutflow,xsec*lumi);
-    h_cutflow->GetXaxis()->SetBinLabel(icutflow+1,"Total (before skim)");
+    h_cutflow->GetXaxis()->SetBinLabel(icutflow+1,"Total");
 
     for( unsigned int event = 0; event < tree->GetEntriesFast(); ++event) {
 
@@ -191,7 +187,7 @@ int ScanChain(TChain *ch, double genEventSumw, TString year, TString process) {
       // After skim
       icutflow = 1;
       h_cutflow->Fill(icutflow,weight*factor);
-      h_cutflow->GetXaxis()->SetBinLabel(icutflow+1,"Total (after skim)");
+      h_cutflow->GetXaxis()->SetBinLabel(icutflow+1,"After skim");
       icutflow++;
 
       // HLT selection
@@ -204,7 +200,7 @@ int ScanChain(TChain *ch, double genEventSumw, TString year, TString process) {
       // Number of good primary vertices
       if ( nt.PV_npvsGood() < 1 ) continue;
       h_cutflow->Fill(icutflow,weight*factor);
-      h_cutflow->GetXaxis()->SetBinLabel(icutflow+1,"At least 1 good PV");
+      h_cutflow->GetXaxis()->SetBinLabel(icutflow+1,"At least one good PV");
       icutflow++;
 
       // Single muon selection loop
@@ -238,7 +234,7 @@ int ScanChain(TChain *ch, double genEventSumw, TString year, TString process) {
 
       if ( !id_req ) continue;
       h_cutflow->Fill(icutflow,weight*factor);
-      h_cutflow->GetXaxis()->SetBinLabel(icutflow+1,"Muon ID (highPt)");
+      h_cutflow->GetXaxis()->SetBinLabel(icutflow+1,"At least two muons w/ highPt ID");
       icutflow++;
 
       //Fill histograms before and after these requirements!
@@ -246,7 +242,7 @@ int ScanChain(TChain *ch, double genEventSumw, TString year, TString process) {
       h_mu2_pt_sel1->Fill(nt.Muon_pt().at(cand_muons_pf_id[1]),weight*factor);
       if ( !pt_req ) continue;
       h_cutflow->Fill(icutflow,weight*factor);
-      h_cutflow->GetXaxis()->SetBinLabel(icutflow+1,"Muon pT>53 GeV & |eta|<2.4");
+      h_cutflow->GetXaxis()->SetBinLabel(icutflow+1,"At least two muons w/ pT>53 GeV & |eta|<2.4");
       icutflow++;
       h_mu1_pt_sel2->Fill(nt.Muon_pt().at(cand_muons_pf_id_and_pteta[0]),weight*factor);
       h_mu2_pt_sel2->Fill(nt.Muon_pt().at(cand_muons_pf_id_and_pteta[1]),weight*factor);
@@ -255,7 +251,7 @@ int ScanChain(TChain *ch, double genEventSumw, TString year, TString process) {
       h_mu2_trkRelIso_sel2->Fill(nt.Muon_tkRelIso().at(cand_muons_pf_id_and_pteta[1]),weight*factor);
       if ( !iso_req ) continue;
       h_cutflow->Fill(icutflow,weight*factor);
-      h_cutflow->GetXaxis()->SetBinLabel(icutflow+1,"Muon track iso./pT<0.1");
+      h_cutflow->GetXaxis()->SetBinLabel(icutflow+1,"At least two muons w/ track iso./pT<0.1");
       icutflow++;
       h_mu1_trkRelIso_sel3->Fill(nt.Muon_tkRelIso().at(cand_muons_pf[0]),weight*factor);
       h_mu2_trkRelIso_sel3->Fill(nt.Muon_tkRelIso().at(cand_muons_pf[1]),weight*factor);
@@ -271,7 +267,7 @@ int ScanChain(TChain *ch, double genEventSumw, TString year, TString process) {
 	  float deta = nt.TrigObj_eta().at(n) - nt.Muon_eta().at(i_cand_muons_pf);
 	  float dphi = TVector2::Phi_mpi_pi(nt.TrigObj_phi().at(n) - nt.Muon_phi().at(i_cand_muons_pf));
 	  float dr = TMath::Sqrt( deta*deta+dphi*dphi );
-	  //h_dr_trigobj_sel3->Fill(dr,weight*factor);
+	  h_dr_trigobj_sel3->Fill(dr,weight*factor);
 	  if ( dr < 0.02 ){
 	    muMatchedToTrigObj.push_back(true);
 	    atLeastSelectedMu_matchedToTrigObj = true;
@@ -281,7 +277,7 @@ int ScanChain(TChain *ch, double genEventSumw, TString year, TString process) {
       }
       if ( !atLeastSelectedMu_matchedToTrigObj ) continue;
       h_cutflow->Fill(icutflow,weight*factor);
-      h_cutflow->GetXaxis()->SetBinLabel(icutflow+1,"At least one muon HLT match");
+      h_cutflow->GetXaxis()->SetBinLabel(icutflow+1,"At least one HLT match (dR<0.02)");
       icutflow++;
 
       h_nCand_Muons_sel4->Fill(cand_muons_pf.size(),weight*factor);
@@ -389,17 +385,6 @@ int ScanChain(TChain *ch, double genEventSumw, TString year, TString process) {
       h_nExtra_electrons_sel5->Fill(extra_electrons.size(),weight*factor);
       h_nExtra_lepIsoTracks_sel5->Fill(extra_isotracks_lep.size(),weight*factor);
       h_nExtra_chhIsoTracks_sel5->Fill(extra_isotracks_chh.size(),weight*factor);
-
-      //if ( extra_muons.size() == 1 ) h_third_mu_pt_sel5->Fill(nt.Muon_pt().at(extra_muons[0]),weight*factor);
-      //if ( extra_electrons.size() == 1 ) h_first_el_pt_sel5->Fill(nt.Electron_pt().at(extra_electrons[0]),weight*factor);
-      //if ( extra_muons.size() > 1 ){
-      //     h_third_mu_pt_sel5->Fill(nt.Muon_pt().at(extra_muons[0]),weight*factor);
-      //	 h_fourth_mu_pt_sel5->Fill(nt.Muon_pt().at(extra_muons[1]),weight*factor); 
-      //}
-      //if ( extra_electrons.size() > 1 ){
-      //     h_first_el_pt_sel5->Fill(nt.Electron_pt().at(extra_electrons[0]),weight*factor);
-      //     h_second_el_pt_sel5->Fill(nt.Electron_pt().at(extra_electrons[1]),weight*factor);
-      //}
  
       if ( extra_muons.size() > 0 || extra_electrons.size() > 0 ) continue;
       h_cutflow->Fill(icutflow,weight*factor);
@@ -433,7 +418,7 @@ int ScanChain(TChain *ch, double genEventSumw, TString year, TString process) {
       h_mll_pf_sel6->Fill(selectedPair_M,weight*factor);
       if ( cand_bJets.size() < 1 ) continue;
       h_cutflow->Fill(icutflow,weight*factor);
-      h_cutflow->GetXaxis()->SetBinLabel(icutflow+1,"At least 1 b-tag");
+      h_cutflow->GetXaxis()->SetBinLabel(icutflow+1,"At least one b-tag");
       icutflow++;
       h_mll_pf_sel7->Fill(selectedPair_M,weight*factor);
       if ( selectedPair_M < 150 ) continue;
@@ -484,6 +469,9 @@ int ScanChain(TChain *ch, double genEventSumw, TString year, TString process) {
       h_cutflow->Fill(icutflow,weight*factor);
       h_cutflow->GetXaxis()->SetBinLabel(icutflow+1,"min m(lb)>175 GeV");
       icutflow++;
+      h_cutflow->GetXaxis()->SetRangeUser(0,icutflow);
+      h_cutflow->GetXaxis()->SetLabelSize(0.025);
+
       h_met_pt_sel9->Fill(pfmet_pt,weight*factor);
       h_met_phi_sel9->Fill(pfmet_phi,weight*factor);
       h_mu1_trkRelIso_sel9->Fill(nt.Muon_tkRelIso().at(leadingMu_idx),weight*factor);
@@ -501,7 +489,7 @@ int ScanChain(TChain *ch, double genEventSumw, TString year, TString process) {
   } // File loop
   bar.finish();
 
-  f1->Write();
-  f1->Close();
+  fout->Write();
+  fout->Close();
   return 0;
 }

--- a/cpp/ScanChain_Zp.C
+++ b/cpp/ScanChain_Zp.C
@@ -95,10 +95,10 @@ int ScanChain(TChain *ch, double genEventSumw, TString year, TString process) {
   // Modify the name of the output file to include arguments of ScanChain function (i.e. process, year, etc.)
   TFile* fout = new TFile("temp_data/output_"+process+"_"+year+".root", "RECREATE");
   H1(cutflow,20,0,20,"");
-  H1(mll_pf_sel6,241,90,2500,"m_{ll} [GeV]");
-  H1(mll_pf_sel7,241,90,2500,"m_{ll} [GeV]");
-  H1(mll_pf_sel8,241,90,2500,"m_{ll} [GeV]");
-  H1(mll_pf_sel9,241,90,2500,"m_{ll} [GeV]");
+  H1(mll_pf_sel6,240,100,2500,"m_{ll} [GeV]");
+  H1(mll_pf_sel7,240,100,2500,"m_{ll} [GeV]");
+  H1(mll_pf_sel8,240,100,2500,"m_{ll} [GeV]");
+  H1(mll_pf_sel9,240,100,2500,"m_{ll} [GeV]");
   H1(mu1_pt_sel1,200,0,1000,"p_{T} (leading #mu) [GeV]");
   H1(mu1_pt_sel2,200,0,1000,"p_{T} (leading #mu) [GeV]");
   H1(mu1_pt_sel8,200,0,1000,"p_{T} (leading #mu) [GeV]");
@@ -115,7 +115,7 @@ int ScanChain(TChain *ch, double genEventSumw, TString year, TString process) {
   H1(mu2_trkRelIso_sel3,50,0,0.5,"Track iso./p_{T} (subleading #mu)");
   H1(mu2_trkRelIso_sel8,50,0,0.1,"Track iso./p_{T} (subleading #mu)");
   H1(mu2_trkRelIso_sel9,50,0,0.1,"Track iso./p_{T} (subleading #mu)");
-  H1(nCand_Muons_sel4,3,2,5,"Number of #mu candidates");
+  H1(nCand_Muons_sel4,4,2,6,"Number of #mu candidates");
   //H1(btagDeepFlavB_sel6,50,0,1,"b-tag deep-flavor discriminant");
   H1(nbtagDeepFlavB_sel6,5,0,5,"Number of b-tags (medium WP)");
   H1(bjet1_pt_sel8,200,0,1000,"p_{T} (leading b-tagged jet) [GeV]");
@@ -211,7 +211,7 @@ int ScanChain(TChain *ch, double genEventSumw, TString year, TString process) {
 	bool mu_trk_and_global = ( nt.Muon_isGlobal().at(mu) && nt.Muon_isTracker().at(mu) );
 	bool mu_id = ( nt.Muon_highPtId().at(mu) == 2 );
 	bool mu_pt_pf = ( nt.Muon_pt().at(mu) > 53 && fabs(nt.Muon_eta().at(mu)) < 2.4 );
-	bool mu_relIso = ( nt.Muon_tkRelIso().at(mu) < 0.02 );
+	bool mu_relIso = ( nt.Muon_tkRelIso().at(mu) < 0.1 );
 	      
 	if ( mu_trk_and_global && mu_id ){
 	  nMu_id++;
@@ -354,7 +354,7 @@ int ScanChain(TChain *ch, double genEventSumw, TString year, TString process) {
 	      mindr = dr;
 	    }
 	  }
-	  if ( mindr > 0.02)
+	  if ( mindr > 0.02 )
 	    extra_isotracks_lep.push_back(i);
         }
       }
@@ -375,7 +375,7 @@ int ScanChain(TChain *ch, double genEventSumw, TString year, TString process) {
 	      mindr = dr;
 	    }
 	  }
-	  if ( mindr > 0.02)
+	  if ( mindr > 0.02 )
 	    extra_isotracks_chh.push_back(i);
         }
       }

--- a/cpp/ScanChain_Zp.C
+++ b/cpp/ScanChain_Zp.C
@@ -35,9 +35,9 @@ int mdir = mkdir(outdir,0755);
 
 struct debugger { template<typename T> debugger& operator , (const T& v) { cerr<<v<<" "; return *this; } } dbg;
 #ifdef DEBUG
-    #define debug(args...) do {cerr << #args << ": "; dbg,args; cerr << endl;} while(0)
+#define debug(args...) do {cerr << #args << ": "; dbg,args; cerr << endl;} while(0)
 #else
-    #define debug(args...)
+#define debug(args...)
 #endif
 
 using namespace std;
@@ -45,459 +45,459 @@ using namespace tas;
 
 int ScanChain(TChain *ch, double genEventSumw, TString year, TString process) {
 
-    float factor = 1.0;
-    float lumi = 1.0;
-    float xsec = 1.0;
-    bool isMC = true;
+  float factor = 1.0;
+  float lumi = 1.0;
+  float xsec = 1.0;
+  bool isMC = true;
  
-    if ( process == "ttbar" )               xsec = 87310.0; // fb
-    if ( process == "DY" )                  xsec = 5765400.0; // fb
-    if ( process == "ZToMuMu_50_120" )      xsec = 2112904.0; // fb
-    if ( process == "ZToMuMu_120_200" )     xsec = 20553.0; // fb
-    if ( process == "ZToMuMu_200_400" )     xsec = 2886.0; // fb
-    if ( process == "ZToMuMu_400_800" )     xsec = 251.7; // fb
-    if ( process == "ZToMuMu_800_1400" )    xsec = 17.07; // fb
-    if ( process == "ZToMuMu_1400_2300" )   xsec = 1.366; // fb
-    if ( process == "ZToMuMu_2300_3500" )   xsec = 0.08178; // fb
-    if ( process == "ZToMuMu_3500_4500" )   xsec = 0.003191; // fb
-    if ( process == "ZToMuMu_4500_6000" )   xsec = 0.0002787; // fb
-    if ( process == "ZToMuMu_6000_Inf" )    xsec = 0.000009569; // fb
-    if ( process == "WW" )                  xsec = 118700.0; // fb 
-    if ( process == "WZ" )                  xsec = 47130.0; // fb
-    if ( process == "ZZ" )                  xsec = 16523.0; // fb
-    if ( process == "tW" )                  xsec = 19550; // fb
-    if ( process == "tbarW" )               xsec = 19550; // fb
-    if ( process == "TTW" )                 xsec = 204.3; // fb
-    if ( process == "TTZ" )                 xsec = 252.9; // fb
-    if ( process == "TTHToNonbb" )          xsec = 507.5*(1-0.575); // fb
-    if ( process == "TTHTobb" )             xsec = 507.5*0.575; // fb
+  if ( process == "ttbar" )               xsec = 87310.0; // fb
+  if ( process == "DY" )                  xsec = 5765400.0; // fb
+  if ( process == "ZToMuMu_50_120" )      xsec = 2112904.0; // fb
+  if ( process == "ZToMuMu_120_200" )     xsec = 20553.0; // fb
+  if ( process == "ZToMuMu_200_400" )     xsec = 2886.0; // fb
+  if ( process == "ZToMuMu_400_800" )     xsec = 251.7; // fb
+  if ( process == "ZToMuMu_800_1400" )    xsec = 17.07; // fb
+  if ( process == "ZToMuMu_1400_2300" )   xsec = 1.366; // fb
+  if ( process == "ZToMuMu_2300_3500" )   xsec = 0.08178; // fb
+  if ( process == "ZToMuMu_3500_4500" )   xsec = 0.003191; // fb
+  if ( process == "ZToMuMu_4500_6000" )   xsec = 0.0002787; // fb
+  if ( process == "ZToMuMu_6000_Inf" )    xsec = 0.000009569; // fb
+  if ( process == "WW" )                  xsec = 118700.0; // fb 
+  if ( process == "WZ" )                  xsec = 47130.0; // fb
+  if ( process == "ZZ" )                  xsec = 16523.0; // fb
+  if ( process == "tW" )                  xsec = 19550; // fb
+  if ( process == "tbarW" )               xsec = 19550; // fb
+  if ( process == "TTW" )                 xsec = 204.3; // fb
+  if ( process == "TTZ" )                 xsec = 252.9; // fb
+  if ( process == "TTHToNonbb" )          xsec = 507.5*(1-0.575); // fb
+  if ( process == "TTHTobb" )             xsec = 507.5*0.575; // fb
 
     
-    if ( year == "2018" )
+  if ( year == "2018" )
     {
-        lumi = 59.83; // fb-1
-        if ( process == "Y3_M100" )     xsec = 0.0211369709127*1000; // fb
-        if ( process == "Y3_M200" )     xsec = 0.01597959*1000; // fb
-        if ( process == "Y3_M400" )     xsec = 0.00290934734735*1000; // fb
-        if ( process == "Y3_M700" )     xsec = 0.000614377054108*1000; // fb
-        if ( process == "Y3_M1000" )    xsec = 0.000192622380952*1000; // fb
-        if ( process == "Y3_M1500" )    xsec = 3.636946e-05*1000; // fb
-        if ( process == "Y3_M2000" )    xsec = 8.253412e-06*1000; // fb
+      lumi = 59.83; // fb-1
+      if ( process == "Y3_M100" )     xsec = 0.0211369709127*1000; // fb
+      if ( process == "Y3_M200" )     xsec = 0.01597959*1000; // fb
+      if ( process == "Y3_M400" )     xsec = 0.00290934734735*1000; // fb
+      if ( process == "Y3_M700" )     xsec = 0.000614377054108*1000; // fb
+      if ( process == "Y3_M1000" )    xsec = 0.000192622380952*1000; // fb
+      if ( process == "Y3_M1500" )    xsec = 3.636946e-05*1000; // fb
+      if ( process == "Y3_M2000" )    xsec = 8.253412e-06*1000; // fb
     }
-    if ( year == "2017" )       lumi = 41.48; // fb-1
-    if ( year == "2016APV" )    lumi = 19.5;  // fb-1
-    if ( year == "2016nonAPV" ) lumi = 16.8;  // fb-1
+  if ( year == "2017" )       lumi = 41.48; // fb-1
+  if ( year == "2016APV" )    lumi = 19.5;  // fb-1
+  if ( year == "2016nonAPV" ) lumi = 16.8;  // fb-1
 
-    factor = xsec*lumi/genEventSumw;
+  factor = xsec*lumi/genEventSumw;
 
-    // Modify the name of the output file to include arguments of ScanChain function (i.e. process, year, etc.)
-    TFile* f1 = new TFile("temp_data/output_"+process+"_"+year+".root", "RECREATE");
-    H1(cutflow,20,0,20);
-    H1(mll_pf_sel6,241,90,2500);
-    H1(mll_pf_sel7,241,90,2500);
-    H1(mll_pf_sel8,241,90,2500);
-    H1(mll_pf_sel9,241,90,2500);
-    H1(mu1_pt_sel1,200,0,1000);
-    H1(mu2_pt_sel1,200,0,1000);
-    H1(mu1_pt_sel2,200,0,1000);
-    H1(mu2_pt_sel2,200,0,1000);
-    H1(mu1_pt_sel8,200,0,1000);
-    H1(mu2_pt_sel8,200,0,1000);
-    H1(mu1_pt_sel9,200,0,1000);
-    H1(mu2_pt_sel9,200,0,1000);
-    H1(mu1_trkRelIso_sel2,50,0,0.5);
-    H1(mu2_trkRelIso_sel2,50,0,0.5);
-    H1(mu1_trkRelIso_sel3,50,0,0.5);
-    H1(mu2_trkRelIso_sel3,50,0,0.5);
-    H1(mu1_trkRelIso_sel8,50,0,0.1);
-    H1(mu2_trkRelIso_sel8,50,0,0.1);
-    H1(mu1_trkRelIso_sel9,50,0,0.1);
-    H1(mu2_trkRelIso_sel9,50,0,0.1);
-    H1(nCand_Muons_sel4,5,0,5);
-    //H1(btagDeepFlavB_sel6,50,0,1);
-    H1(nbtagDeepFlavB_sel6,5,0,5);
-    H1(bjet1_pt_sel8,200,0,1000);
-    H1(bjet2_pt_sel8,200,0,1000);
-    H1(min_mlb_sel8,200,0,2000);
-    H1(min_mlb_sel9,200,0,2000);
-    H1(met_pt_sel8,120,0,600);
-    H1(met_pt_sel9,120,0,600);
-    H1(met_phi_sel8,65,-3.25,3.25);
-    H1(met_phi_sel9,65,-3.25,3.25);
-    H1(nExtra_muons_sel5,6,0,6);
-    H1(nExtra_electrons_sel5,6,0,6);
-    H1(nExtra_lepIsoTracks_sel5,6,0,6);
-    H1(nExtra_chhIsoTracks_sel5,6,0,6);
-    //H1(third_mu_pt_sel5,100,0,500);
-    //H1(fourth_mu_pt_sel5,100,0,500);
-    //H1(first_el_pt_sel5,100,0,500);
-    //H1(second_el_pt_sel5,100,0,500);
-    //H1(dr_trigobj_sel3,50,0,0.5);
+  // Modify the name of the output file to include arguments of ScanChain function (i.e. process, year, etc.)
+  TFile* f1 = new TFile("temp_data/output_"+process+"_"+year+".root", "RECREATE");
+  H1(cutflow,20,0,20);
+  H1(mll_pf_sel6,241,90,2500);
+  H1(mll_pf_sel7,241,90,2500);
+  H1(mll_pf_sel8,241,90,2500);
+  H1(mll_pf_sel9,241,90,2500);
+  H1(mu1_pt_sel1,200,0,1000);
+  H1(mu2_pt_sel1,200,0,1000);
+  H1(mu1_pt_sel2,200,0,1000);
+  H1(mu2_pt_sel2,200,0,1000);
+  H1(mu1_pt_sel8,200,0,1000);
+  H1(mu2_pt_sel8,200,0,1000);
+  H1(mu1_pt_sel9,200,0,1000);
+  H1(mu2_pt_sel9,200,0,1000);
+  H1(mu1_trkRelIso_sel2,50,0,0.5);
+  H1(mu2_trkRelIso_sel2,50,0,0.5);
+  H1(mu1_trkRelIso_sel3,50,0,0.5);
+  H1(mu2_trkRelIso_sel3,50,0,0.5);
+  H1(mu1_trkRelIso_sel8,50,0,0.1);
+  H1(mu2_trkRelIso_sel8,50,0,0.1);
+  H1(mu1_trkRelIso_sel9,50,0,0.1);
+  H1(mu2_trkRelIso_sel9,50,0,0.1);
+  H1(nCand_Muons_sel4,5,0,5);
+  //H1(btagDeepFlavB_sel6,50,0,1);
+  H1(nbtagDeepFlavB_sel6,5,0,5);
+  H1(bjet1_pt_sel8,200,0,1000);
+  H1(bjet2_pt_sel8,200,0,1000);
+  H1(min_mlb_sel8,200,0,2000);
+  H1(min_mlb_sel9,200,0,2000);
+  H1(met_pt_sel8,120,0,600);
+  H1(met_pt_sel9,120,0,600);
+  H1(met_phi_sel8,65,-3.25,3.25);
+  H1(met_phi_sel9,65,-3.25,3.25);
+  H1(nExtra_muons_sel5,6,0,6);
+  H1(nExtra_electrons_sel5,6,0,6);
+  H1(nExtra_lepIsoTracks_sel5,6,0,6);
+  H1(nExtra_chhIsoTracks_sel5,6,0,6);
+  //H1(third_mu_pt_sel5,100,0,500);
+  //H1(fourth_mu_pt_sel5,100,0,500);
+  //H1(first_el_pt_sel5,100,0,500);
+  //H1(second_el_pt_sel5,100,0,500);
+  //H1(dr_trigobj_sel3,50,0,0.5);
 
-    int nEventsTotal = 0;
-    int nEvents_more_leps = 0;
-    int nEventsChain = ch->GetEntries();
-    TFile *currentFile = 0;
-    TObjArray *listOfFiles = ch->GetListOfFiles();
-    TIter fileIter(listOfFiles);
-    tqdm bar;
+  int nEventsTotal = 0;
+  int nEvents_more_leps = 0;
+  int nEventsChain = ch->GetEntries();
+  TFile *currentFile = 0;
+  TObjArray *listOfFiles = ch->GetListOfFiles();
+  TIter fileIter(listOfFiles);
+  tqdm bar;
 
-    while ( (currentFile = (TFile*)fileIter.Next()) ) {
-        TFile *file = TFile::Open( currentFile->GetTitle() );
-        TTree *tree = (TTree*)file->Get("Events");
-        TString filename(currentFile->GetTitle());
+  while ( (currentFile = (TFile*)fileIter.Next()) ) {
+    TFile *file = TFile::Open( currentFile->GetTitle() );
+    TTree *tree = (TTree*)file->Get("Events");
+    TString filename(currentFile->GetTitle());
 
-        tree->SetCacheSize(128*1024*1024);
-        tree->SetCacheLearnEntries(100);
+    tree->SetCacheSize(128*1024*1024);
+    tree->SetCacheLearnEntries(100);
 
-        nt.Init(tree);
+    nt.Init(tree);
 
-	// Before any cuts
-	int icutflow = 0;
-	h_cutflow->Fill(icutflow,xsec*lumi);
-	h_cutflow->GetXaxis()->SetBinLabel(icutflow+1,"Total (before skim)");
+    // Before any cuts
+    int icutflow = 0;
+    h_cutflow->Fill(icutflow,xsec*lumi);
+    h_cutflow->GetXaxis()->SetBinLabel(icutflow+1,"Total (before skim)");
 
-        for( unsigned int event = 0; event < tree->GetEntriesFast(); ++event) {
+    for( unsigned int event = 0; event < tree->GetEntriesFast(); ++event) {
 
-            nt.GetEntry(event);
-            tree->LoadTree(event);
+      nt.GetEntry(event);
+      tree->LoadTree(event);
 
-            float weight = genWeight();
-	    if(weight>1e3) continue;
+      float weight = genWeight();
+      if(weight>1e3) continue;
 
-	    int runnb = nt.run();
-	    int npv = nt.PV_npvs();
+      int runnb = nt.run();
+      int npv = nt.PV_npvs();
 
-	    // MET xy correction: https://twiki.cern.ch/twiki/bin/viewauth/CMS/MissingETRun2Corrections#xy_Shift_Correction_MET_phi_modu
-	    // METXYCorr_Met_MetPhi(double uncormet, double uncormet_phi, int runnb, TString year, bool isMC, int npv, bool isUL =false,bool ispuppi=false)
-	    std::pair<double,double> pfmet = METXYCorr_Met_MetPhi(nt.MET_pt(), nt.MET_phi(), runnb, year, isMC, npv, true, false);
-	    double pfmet_pt  = pfmet.first;
-	    double pfmet_phi = pfmet.second;
-	    //std::pair<double,double> puppimet = METXYCorr_Met_MetPhi(nt.PuppiMET_pt(), nt.PuppiMET_phi(), runnb, year, isMC, npv, true, true);
-	    //double puppimet_pt  = puppimet.first;
-	    //double puppimet_phi = puppimet.second;
+      // MET xy correction: https://twiki.cern.ch/twiki/bin/viewauth/CMS/MissingETRun2Corrections#xy_Shift_Correction_MET_phi_modu
+      // METXYCorr_Met_MetPhi(double uncormet, double uncormet_phi, int runnb, TString year, bool isMC, int npv, bool isUL =false,bool ispuppi=false)
+      std::pair<double,double> pfmet = METXYCorr_Met_MetPhi(nt.MET_pt(), nt.MET_phi(), runnb, year, isMC, npv, true, false);
+      double pfmet_pt  = pfmet.first;
+      double pfmet_phi = pfmet.second;
+      //std::pair<double,double> puppimet = METXYCorr_Met_MetPhi(nt.PuppiMET_pt(), nt.PuppiMET_phi(), runnb, year, isMC, npv, true, true);
+      //double puppimet_pt  = puppimet.first;
+      //double puppimet_phi = puppimet.second;
 
-            // Define vector of muon candidate indices here.....
-            vector<int> cand_muons_pf_id;
-            vector<int> cand_muons_pf_id_and_pteta;
-            vector<int> cand_muons_pf;
-            //vector<int> cand_muons_tunep;
+      // Define vector of muon candidate indices here.....
+      vector<int> cand_muons_pf_id;
+      vector<int> cand_muons_pf_id_and_pteta;
+      vector<int> cand_muons_pf;
+      //vector<int> cand_muons_tunep;
 
-            nEventsTotal++;
-            bar.progress(nEventsTotal, nEventsChain);
+      nEventsTotal++;
+      bar.progress(nEventsTotal, nEventsChain);
 
-            // After skim
-	    icutflow = 1;
-            h_cutflow->Fill(icutflow,weight*factor);
-	    h_cutflow->GetXaxis()->SetBinLabel(icutflow+1,"Total (after skim)");
-            icutflow++;
+      // After skim
+      icutflow = 1;
+      h_cutflow->Fill(icutflow,weight*factor);
+      h_cutflow->GetXaxis()->SetBinLabel(icutflow+1,"Total (after skim)");
+      icutflow++;
 
-            // HLT selection
-            if ( (year=="2016nonAPV" || year=="2016APV") && !( nt.HLT_Mu50() || nt.HLT_TkMu50() ) ) continue;
-            if ( (year=="2017" || year=="2018") && !(nt.HLT_Mu50() || nt.HLT_OldMu100() || nt.HLT_TkMu100()) ) continue;
-            h_cutflow->Fill(icutflow,weight*factor);
-	    h_cutflow->GetXaxis()->SetBinLabel(icutflow+1,"HLT");
-            icutflow++;
+      // HLT selection
+      if ( (year=="2016nonAPV" || year=="2016APV") && !( nt.HLT_Mu50() || nt.HLT_TkMu50() ) ) continue;
+      if ( (year=="2017" || year=="2018") && !(nt.HLT_Mu50() || nt.HLT_OldMu100() || nt.HLT_TkMu100()) ) continue;
+      h_cutflow->Fill(icutflow,weight*factor);
+      h_cutflow->GetXaxis()->SetBinLabel(icutflow+1,"HLT");
+      icutflow++;
 
-            // Number of good primary vertices
-            if ( nt.PV_npvsGood() < 1 ) continue;
-            h_cutflow->Fill(icutflow,weight*factor);
-	    h_cutflow->GetXaxis()->SetBinLabel(icutflow+1,"At least 1 good PV");
-            icutflow++;
+      // Number of good primary vertices
+      if ( nt.PV_npvsGood() < 1 ) continue;
+      h_cutflow->Fill(icutflow,weight*factor);
+      h_cutflow->GetXaxis()->SetBinLabel(icutflow+1,"At least 1 good PV");
+      icutflow++;
 
-            // Single muon selection loop
-            int nMu_id = 0;
-            int nMu_pt = 0;
-            int nMu_iso = 0;
-            for ( unsigned int mu = 0; mu < nt.nMuon(); mu++ ){
-	      bool mu_trk_and_global = ( nt.Muon_isGlobal().at(mu) && nt.Muon_isTracker().at(mu) );
-	      bool mu_id = ( nt.Muon_highPtId().at(mu) == 2 );
-	      bool mu_pt_pf = ( nt.Muon_pt().at(mu) > 53 && fabs(nt.Muon_eta().at(mu)) < 2.4 );
-	      bool mu_relIso = ( nt.Muon_tkRelIso().at(mu) < 0.02 );
+      // Single muon selection loop
+      int nMu_id = 0;
+      int nMu_pt = 0;
+      int nMu_iso = 0;
+      for ( unsigned int mu = 0; mu < nt.nMuon(); mu++ ){
+	bool mu_trk_and_global = ( nt.Muon_isGlobal().at(mu) && nt.Muon_isTracker().at(mu) );
+	bool mu_id = ( nt.Muon_highPtId().at(mu) == 2 );
+	bool mu_pt_pf = ( nt.Muon_pt().at(mu) > 53 && fabs(nt.Muon_eta().at(mu)) < 2.4 );
+	bool mu_relIso = ( nt.Muon_tkRelIso().at(mu) < 0.02 );
 	      
-	      if ( mu_trk_and_global && mu_id ){
-		nMu_id++;
-		cand_muons_pf_id.push_back(mu);
-		if ( mu_pt_pf ){
-		  nMu_pt++;
-		  cand_muons_pf_id_and_pteta.push_back(mu);
-		  if ( mu_relIso ){
-		    nMu_iso++;
-		    cand_muons_pf.push_back(mu);
-		  }
-		}
-	      }
-            }
-	    
-            // Defining booleans for cutflow
-            bool id_req = ( nMu_id > 1 );
-            bool pt_req = ( nMu_pt > 1 );
-            bool iso_req = ( nMu_iso > 1);
-
-            if ( !id_req ) continue;
-            h_cutflow->Fill(icutflow,weight*factor);
-	    h_cutflow->GetXaxis()->SetBinLabel(icutflow+1,"Muon ID (highPt)");
-            icutflow++;
-
-            //Fill histograms before and after these requirements!
-            h_mu1_pt_sel1->Fill(nt.Muon_pt().at(cand_muons_pf_id[0]),weight*factor);
-            h_mu2_pt_sel1->Fill(nt.Muon_pt().at(cand_muons_pf_id[1]),weight*factor);
-            if ( !pt_req ) continue;
-            h_cutflow->Fill(icutflow,weight*factor);
-	    h_cutflow->GetXaxis()->SetBinLabel(icutflow+1,"Muon pT>53 GeV & |eta|<2.4");
-            icutflow++;
-            h_mu1_pt_sel2->Fill(nt.Muon_pt().at(cand_muons_pf_id_and_pteta[0]),weight*factor);
-            h_mu2_pt_sel2->Fill(nt.Muon_pt().at(cand_muons_pf_id_and_pteta[1]),weight*factor);
-
-            h_mu1_trkRelIso_sel2->Fill(nt.Muon_tkRelIso().at(cand_muons_pf_id_and_pteta[0]),weight*factor);
-            h_mu2_trkRelIso_sel2->Fill(nt.Muon_tkRelIso().at(cand_muons_pf_id_and_pteta[1]),weight*factor);
-            if ( !iso_req ) continue;
-            h_cutflow->Fill(icutflow,weight*factor);
-	    h_cutflow->GetXaxis()->SetBinLabel(icutflow+1,"Muon track iso./pT<0.1");
-            icutflow++;
-            h_mu1_trkRelIso_sel3->Fill(nt.Muon_tkRelIso().at(cand_muons_pf[0]),weight*factor);
-            h_mu2_trkRelIso_sel3->Fill(nt.Muon_tkRelIso().at(cand_muons_pf[1]),weight*factor);
-
-
-            // Trigger object finding
-            bool atLeastSelectedMu_matchedToTrigObj = false;
-            vector<bool> muMatchedToTrigObj;
-            for ( int n = 0; n < nt.nTrigObj(); n++ ){
-                if ( abs(nt.TrigObj_id().at(n)) != 13 ) continue;
-		        if ( !(nt.TrigObj_filterBits().at(n) & 8) ) continue;
-                for ( auto i_cand_muons_pf : cand_muons_pf ){
-                    float deta = nt.TrigObj_eta().at(n) - nt.Muon_eta().at(i_cand_muons_pf);
-                    float dphi = TVector2::Phi_mpi_pi(nt.TrigObj_phi().at(n) - nt.Muon_phi().at(i_cand_muons_pf));
-                    float dr = TMath::Sqrt( deta*deta+dphi*dphi );
-		    //h_dr_trigobj_sel3->Fill(dr,weight*factor);
-                    if ( dr < 0.02 ){
-                        muMatchedToTrigObj.push_back(true);
-                        atLeastSelectedMu_matchedToTrigObj = true;
-                    }
-                    else muMatchedToTrigObj.push_back(false);
-                }
-	        }
-            if ( !atLeastSelectedMu_matchedToTrigObj ) continue;
-            h_cutflow->Fill(icutflow,weight*factor);
-	    h_cutflow->GetXaxis()->SetBinLabel(icutflow+1,"At least one muon HLT match");
-            icutflow++;
-
-            h_nCand_Muons_sel4->Fill(cand_muons_pf.size(),weight*factor);
-
-            int leadingMu_idx = -1, subleadingMu_idx = -1;
-            float selectedPair_M = -1.0;
-            bool Zboson = false;
-            for ( unsigned int i=0; i<cand_muons_pf.size(); i++ ){
-                TVector3 mu_1(nt.Muon_p4().at(cand_muons_pf[i]).Px(),nt.Muon_p4().at(cand_muons_pf[i]).Py(),nt.Muon_p4().at(cand_muons_pf[i]).Pz());
-                for ( unsigned int j=i+1; j<cand_muons_pf.size(); j++ ){
-                    if ( nt.Muon_pdgId().at(cand_muons_pf[i]) + nt.Muon_pdgId().at(cand_muons_pf[j]) != 0 ) continue; // Opposite sign, same flavor
-                    if ( !(muMatchedToTrigObj[i] || muMatchedToTrigObj[j]) ) continue; // At least one muon in pair matched to HLT
-                    TVector3 mu_2(nt.Muon_p4().at(cand_muons_pf[j]).Px(),nt.Muon_p4().at(cand_muons_pf[j]).Py(),nt.Muon_p4().at(cand_muons_pf[j]).Pz());
-                    if ( !(IsSeparated( mu_1,mu_2 ) ) ) continue; // 3D angle between muons > pi - 0.02
-                    float m_ll_pf = (nt.Muon_p4().at(cand_muons_pf[i])+nt.Muon_p4().at(cand_muons_pf[j])).M();
-                    if ( m_ll_pf > 70 && m_ll_pf < 110 ){ // Reject event if it contains dimuon pair compatible with Z mass
-                        Zboson = true;
-                        continue;
-                    }
-                    if ( selectedPair_M < 0.0 ){
-                        leadingMu_idx = cand_muons_pf[i];
-                        subleadingMu_idx = cand_muons_pf[j];
-                        selectedPair_M = m_ll_pf;
-                    }
-                }
-                if ( Zboson ) break;
-            }
-            if ( selectedPair_M < 0.0 ) continue;
-            if ( Zboson ) continue;
-            h_cutflow->Fill(icutflow,weight*factor);
-	    h_cutflow->GetXaxis()->SetBinLabel(icutflow+1,"Muon pair (OS, !Z)");
-            icutflow++;
-
-            // Look for a third isolated lepton and then veto the event if it is found
-            // Muons
-            vector<int> extra_muons;
-            for ( int i = 0; i < nt.nMuon(); i++ ){
-	      if ( nt.Muon_pt().at(i) > 10. && 
-		   fabs(nt.Muon_eta().at(i)) < 2.4 &&
-		   nt.Muon_looseId().at(i) > 0 && 
-		   fabs(nt.Muon_dxy().at(i)) < 0.2 && fabs(nt.Muon_dz().at(i)) < 0.5 &&
-		   nt.Muon_miniPFRelIso_all().at(i) < 0.2 &&
-		   !( i == leadingMu_idx || i == subleadingMu_idx)){
-		extra_muons.push_back(i);
-	      }
-            }
-
-            // Electrons
-            vector<int> extra_electrons;
-            for ( int i = 0; i < nt.nElectron(); i++ ){
-	      if ( nt.Electron_pt().at(i) > 10. &&
-		   fabs(nt.Electron_eta().at(i)) < 2.4 &&
-		   nt.Electron_cutBased().at(i) > 0 && 
-		   nt.Electron_miniPFRelIso_all().at(i) < 0.1){
-		extra_electrons.push_back(i);
-	      }
-            }
-
-            //// IsoTracks
-            //vector<int> extra_isotracks_lep;
-            //for ( int i = 0; i < nt.nIsoTrack(); i++ ){
-	    //  if ( nt.IsoTrack_isPFcand().at(i) && 
-	    //	   nt.IsoTrack_pt().at(i) > 5. && (abs(nt.IsoTrack_pdgId().at(i))==11 || (abs(nt.IsoTrack_pdgId().at(i))==13)) &&
-	    //	   fabs(nt.IsoTrack_eta().at(i)) < 2.4 &&
-	    //	   fabs(nt.IsoTrack_dz().at(i)) < 0.1 &&
-	    //	   nt.IsoTrack_pfRelIso03_chg().at(i) < 0.2){
-	    //	float mindr=1e9;
-            //    for ( auto i_cand_muons_pf : cand_muons_pf ){
-	    //	  float deta = nt.IsoTrack_eta().at(i) - nt.Muon_eta().at(i_cand_muons_pf);
-	    //	  float dphi = TVector2::Phi_mpi_pi(nt.IsoTrack_phi().at(i) - nt.Muon_phi().at(i_cand_muons_pf));
-	    //	  float dr = TMath::Sqrt( deta*deta+dphi*dphi );
-	    //	  if ( dr < mindr ){
-	    //	    mindr = dr;
-	    //	  }
-	    //	}
-	    //	if ( mindr > 0.02)
-	    //	  extra_isotracks_lep.push_back(i);
-	    //  }
-	    //}
-            //vector<int> extra_isotracks_chh;
-            //for ( int i = 0; i < nt.nIsoTrack(); i++ ){
-	    //  if ( nt.IsoTrack_isPFcand().at(i) && 
-	    //	   nt.IsoTrack_pt().at(i) > 10. && abs(nt.IsoTrack_pdgId().at(i))==211 &&
-	    //	   fabs(nt.IsoTrack_eta().at(i)) < 2.4 &&
-	    //	   fabs(nt.IsoTrack_dz().at(i)) < 0.1 &&
-	    //	   nt.IsoTrack_pfRelIso03_chg().at(i) < 0.1){
-	    //	float mindr=1e9;
-            //    for ( auto i_cand_muons_pf : cand_muons_pf ){
-	    //	  float deta = nt.IsoTrack_eta().at(i) - nt.Muon_eta().at(i_cand_muons_pf);
-	    //	  float dphi = TVector2::Phi_mpi_pi(nt.IsoTrack_phi().at(i) - nt.Muon_phi().at(i_cand_muons_pf));
-	    //	  float dr = TMath::Sqrt( deta*deta+dphi*dphi );
-	    //	  if ( dr < mindr ){
-	    //	    mindr = dr;
-	    //	  }
-	    //	}
-	    //	if ( mindr > 0.02)
-	    //	  extra_isotracks_chh.push_back(i);
-	    //  }
-            //}
-
-            //Fill relevant histograms for extra electrons, muons
-            h_nExtra_muons_sel5->Fill(extra_muons.size(),weight*factor);
-            h_nExtra_electrons_sel5->Fill(extra_electrons.size(),weight*factor);
-            //h_nExtra_lepIsoTracks_sel5->Fill(extra_isotracks_lep.size(),weight*factor);
-            //h_nExtra_chhIsoTracks_sel5->Fill(extra_isotracks_chh.size(),weight*factor);
-
-            //if ( extra_muons.size() == 1 ) h_third_mu_pt_sel5->Fill(nt.Muon_pt().at(extra_muons[0]),weight*factor);
-            //if ( extra_electrons.size() == 1 ) h_first_el_pt_sel5->Fill(nt.Electron_pt().at(extra_electrons[0]),weight*factor);
-            //if ( extra_muons.size() > 1 ){
-            //     h_third_mu_pt_sel5->Fill(nt.Muon_pt().at(extra_muons[0]),weight*factor);
-	    //	 h_fourth_mu_pt_sel5->Fill(nt.Muon_pt().at(extra_muons[1]),weight*factor); 
-            //}
-            //if ( extra_electrons.size() > 1 ){
-            //     h_first_el_pt_sel5->Fill(nt.Electron_pt().at(extra_electrons[0]),weight*factor);
-            //     h_second_el_pt_sel5->Fill(nt.Electron_pt().at(extra_electrons[1]),weight*factor);
-            //}
- 
-            if ( extra_muons.size() > 0 || extra_electrons.size() > 0 ) continue;
-            h_cutflow->Fill(icutflow,weight*factor);
-	    h_cutflow->GetXaxis()->SetBinLabel(icutflow+1,"Third lepton veto");
-            icutflow++;
-
-            //if ( extra_lepIsoTracks.size() > 0 || extra_isotracks_chh.size() > 0 ) continue;
-            //h_cutflow->Fill(icutflow,weight*factor);
-	    //h_cutflow->GetXaxis()->SetBinLabel(icutflow+1,"IsoTrack veto");
-            //icutflow++;
-
-            vector<int> cand_bJets;
-            unsigned int nbtagDeepFlavB = 0;
-            //bool mu_jet_sep = true;
-            for ( unsigned int jet = 0; jet < nt.nJet(); jet++ ) {
-                float d_eta_1 = nt.Muon_eta().at(leadingMu_idx) - nt.Jet_eta().at(jet);
-                float d_eta_2 = nt.Muon_eta().at(subleadingMu_idx) - nt.Jet_eta().at(jet);
-                float d_phi_1 = TVector2::Phi_mpi_pi(nt.Muon_phi().at(leadingMu_idx) - nt.Jet_phi().at(jet));
-                float d_phi_2 = TVector2::Phi_mpi_pi(nt.Muon_phi().at(subleadingMu_idx) - nt.Jet_phi().at(jet));
-                float dr_jmu1 = TMath::Sqrt( d_eta_1*d_eta_1+d_phi_1*d_phi_1 );
-                float dr_jmu2 = TMath::Sqrt( d_eta_2*d_eta_2+d_phi_2*d_phi_2 );
-                // Reject jets if they are within dR = 0.4 of the candidate leptons
-                if ( dr_jmu1 < 0.4 || dr_jmu2 < 0.4 ) continue;
-                if ( nt.Jet_pt().at(jet) > 30 && nt.Jet_jetId().at(jet) > 0 && nt.Jet_btagDeepFlavB().at(jet) > 0.2783 ) // 0.0490 for loose, 0.7100 for tight
-                {
-                    cand_bJets.push_back(jet);  // Medium DeepJet WP
-                    //h_btagDeepFlavB_sel6->Fill(nt.Jet_btagDeepFlavB().at(jet),weight*factor);
-                }
-            }
-            h_nbtagDeepFlavB_sel6->Fill(cand_bJets.size(),weight*factor);
-            h_mll_pf_sel6->Fill(selectedPair_M,weight*factor);
-            if ( cand_bJets.size() < 1 ) continue;
-            h_cutflow->Fill(icutflow,weight*factor);
-	    h_cutflow->GetXaxis()->SetBinLabel(icutflow+1,"At least 1 b-tag");
-            icutflow++;
-            h_mll_pf_sel7->Fill(selectedPair_M,weight*factor);
-            if ( selectedPair_M < 150 ) continue;
-            h_cutflow->Fill(icutflow,weight*factor);
-	    h_cutflow->GetXaxis()->SetBinLabel(icutflow+1,"m(ll)>150 GeV");
-            icutflow++;
-
-            //Fill pT distributions for the bjets....
-            if ( cand_bJets.size() == 1 ){
-                 h_bjet1_pt_sel8->Fill(nt.Jet_pt().at(cand_bJets[0]),weight*factor);
-            }
-
-            if ( cand_bJets.size() > 1 ){
-                 h_bjet1_pt_sel8->Fill(nt.Jet_pt().at(cand_bJets[0]),weight*factor);
- 		 h_bjet2_pt_sel8->Fill(nt.Jet_pt().at(cand_bJets[1]),weight*factor);
-            }
-
-
-            //Construct mlb pairs from selected muon pair and candidate b jets
-            //float m_lb = 0;
-            vector<float> m_lb_vec;
-            for ( int bjet = 0; bjet < cand_bJets.size(); bjet++ ){
-                  if ( bjet > 2 ) continue;
-		  float m_mu1_b = (nt.Muon_p4().at(leadingMu_idx)+nt.Jet_p4().at(cand_bJets[bjet])).M();
-                  float m_mu2_b = (nt.Muon_p4().at(subleadingMu_idx)+nt.Jet_p4().at(cand_bJets[bjet])).M();
-		  m_lb_vec.push_back(m_mu1_b);
-		  m_lb_vec.push_back(m_mu2_b);		  
+	if ( mu_trk_and_global && mu_id ){
+	  nMu_id++;
+	  cand_muons_pf_id.push_back(mu);
+	  if ( mu_pt_pf ){
+	    nMu_pt++;
+	    cand_muons_pf_id_and_pteta.push_back(mu);
+	    if ( mu_relIso ){
+	      nMu_iso++;
+	      cand_muons_pf.push_back(mu);
 	    }
+	  }
+	}
+      }
+	    
+      // Defining booleans for cutflow
+      bool id_req = ( nMu_id > 1 );
+      bool pt_req = ( nMu_pt > 1 );
+      bool iso_req = ( nMu_iso > 1);
+
+      if ( !id_req ) continue;
+      h_cutflow->Fill(icutflow,weight*factor);
+      h_cutflow->GetXaxis()->SetBinLabel(icutflow+1,"Muon ID (highPt)");
+      icutflow++;
+
+      //Fill histograms before and after these requirements!
+      h_mu1_pt_sel1->Fill(nt.Muon_pt().at(cand_muons_pf_id[0]),weight*factor);
+      h_mu2_pt_sel1->Fill(nt.Muon_pt().at(cand_muons_pf_id[1]),weight*factor);
+      if ( !pt_req ) continue;
+      h_cutflow->Fill(icutflow,weight*factor);
+      h_cutflow->GetXaxis()->SetBinLabel(icutflow+1,"Muon pT>53 GeV & |eta|<2.4");
+      icutflow++;
+      h_mu1_pt_sel2->Fill(nt.Muon_pt().at(cand_muons_pf_id_and_pteta[0]),weight*factor);
+      h_mu2_pt_sel2->Fill(nt.Muon_pt().at(cand_muons_pf_id_and_pteta[1]),weight*factor);
+
+      h_mu1_trkRelIso_sel2->Fill(nt.Muon_tkRelIso().at(cand_muons_pf_id_and_pteta[0]),weight*factor);
+      h_mu2_trkRelIso_sel2->Fill(nt.Muon_tkRelIso().at(cand_muons_pf_id_and_pteta[1]),weight*factor);
+      if ( !iso_req ) continue;
+      h_cutflow->Fill(icutflow,weight*factor);
+      h_cutflow->GetXaxis()->SetBinLabel(icutflow+1,"Muon track iso./pT<0.1");
+      icutflow++;
+      h_mu1_trkRelIso_sel3->Fill(nt.Muon_tkRelIso().at(cand_muons_pf[0]),weight*factor);
+      h_mu2_trkRelIso_sel3->Fill(nt.Muon_tkRelIso().at(cand_muons_pf[1]),weight*factor);
+
+
+      // Trigger object finding
+      bool atLeastSelectedMu_matchedToTrigObj = false;
+      vector<bool> muMatchedToTrigObj;
+      for ( int n = 0; n < nt.nTrigObj(); n++ ){
+	if ( abs(nt.TrigObj_id().at(n)) != 13 ) continue;
+	if ( !(nt.TrigObj_filterBits().at(n) & 8) ) continue;
+	for ( auto i_cand_muons_pf : cand_muons_pf ){
+	  float deta = nt.TrigObj_eta().at(n) - nt.Muon_eta().at(i_cand_muons_pf);
+	  float dphi = TVector2::Phi_mpi_pi(nt.TrigObj_phi().at(n) - nt.Muon_phi().at(i_cand_muons_pf));
+	  float dr = TMath::Sqrt( deta*deta+dphi*dphi );
+	  //h_dr_trigobj_sel3->Fill(dr,weight*factor);
+	  if ( dr < 0.02 ){
+	    muMatchedToTrigObj.push_back(true);
+	    atLeastSelectedMu_matchedToTrigObj = true;
+	  }
+	  else muMatchedToTrigObj.push_back(false);
+	}
+      }
+      if ( !atLeastSelectedMu_matchedToTrigObj ) continue;
+      h_cutflow->Fill(icutflow,weight*factor);
+      h_cutflow->GetXaxis()->SetBinLabel(icutflow+1,"At least one muon HLT match");
+      icutflow++;
+
+      h_nCand_Muons_sel4->Fill(cand_muons_pf.size(),weight*factor);
+
+      int leadingMu_idx = -1, subleadingMu_idx = -1;
+      float selectedPair_M = -1.0;
+      bool Zboson = false;
+      for ( unsigned int i=0; i<cand_muons_pf.size(); i++ ){
+	TVector3 mu_1(nt.Muon_p4().at(cand_muons_pf[i]).Px(),nt.Muon_p4().at(cand_muons_pf[i]).Py(),nt.Muon_p4().at(cand_muons_pf[i]).Pz());
+	for ( unsigned int j=i+1; j<cand_muons_pf.size(); j++ ){
+	  if ( nt.Muon_pdgId().at(cand_muons_pf[i]) + nt.Muon_pdgId().at(cand_muons_pf[j]) != 0 ) continue; // Opposite sign, same flavor
+	  if ( !(muMatchedToTrigObj[i] || muMatchedToTrigObj[j]) ) continue; // At least one muon in pair matched to HLT
+	  TVector3 mu_2(nt.Muon_p4().at(cand_muons_pf[j]).Px(),nt.Muon_p4().at(cand_muons_pf[j]).Py(),nt.Muon_p4().at(cand_muons_pf[j]).Pz());
+	  if ( !(IsSeparated( mu_1,mu_2 ) ) ) continue; // 3D angle between muons > pi - 0.02
+	  float m_ll_pf = (nt.Muon_p4().at(cand_muons_pf[i])+nt.Muon_p4().at(cand_muons_pf[j])).M();
+	  if ( m_ll_pf > 70 && m_ll_pf < 110 ){ // Reject event if it contains dimuon pair compatible with Z mass
+	    Zboson = true;
+	    continue;
+	  }
+	  if ( selectedPair_M < 0.0 ){
+	    leadingMu_idx = cand_muons_pf[i];
+	    subleadingMu_idx = cand_muons_pf[j];
+	    selectedPair_M = m_ll_pf;
+	  }
+	}
+	if ( Zboson ) break;
+      }
+      if ( selectedPair_M < 0.0 ) continue;
+      if ( Zboson ) continue;
+      h_cutflow->Fill(icutflow,weight*factor);
+      h_cutflow->GetXaxis()->SetBinLabel(icutflow+1,"Muon pair (OS, !Z)");
+      icutflow++;
+
+      // Look for a third isolated lepton and then veto the event if it is found
+      // Muons
+      vector<int> extra_muons;
+      for ( int i = 0; i < nt.nMuon(); i++ ){
+	if ( nt.Muon_pt().at(i) > 10. && 
+	     fabs(nt.Muon_eta().at(i)) < 2.4 &&
+	     nt.Muon_looseId().at(i) > 0 && 
+	     fabs(nt.Muon_dxy().at(i)) < 0.2 && fabs(nt.Muon_dz().at(i)) < 0.5 &&
+	     nt.Muon_miniPFRelIso_all().at(i) < 0.2 &&
+	     !( i == leadingMu_idx || i == subleadingMu_idx)){
+	  extra_muons.push_back(i);
+	}
+      }
+
+      // Electrons
+      vector<int> extra_electrons;
+      for ( int i = 0; i < nt.nElectron(); i++ ){
+	if ( nt.Electron_pt().at(i) > 10. &&
+	     fabs(nt.Electron_eta().at(i)) < 2.4 &&
+	     nt.Electron_cutBased().at(i) > 0 && 
+	     nt.Electron_miniPFRelIso_all().at(i) < 0.1){
+	  extra_electrons.push_back(i);
+	}
+      }
+
+      //// IsoTracks
+      //vector<int> extra_isotracks_lep;
+      //for ( int i = 0; i < nt.nIsoTrack(); i++ ){
+      //  if ( nt.IsoTrack_isPFcand().at(i) && 
+      //	   nt.IsoTrack_pt().at(i) > 5. && (abs(nt.IsoTrack_pdgId().at(i))==11 || (abs(nt.IsoTrack_pdgId().at(i))==13)) &&
+      //	   fabs(nt.IsoTrack_eta().at(i)) < 2.4 &&
+      //	   fabs(nt.IsoTrack_dz().at(i)) < 0.1 &&
+      //	   nt.IsoTrack_pfRelIso03_chg().at(i) < 0.2){
+      //	float mindr=1e9;
+      //    for ( auto i_cand_muons_pf : cand_muons_pf ){
+      //	  float deta = nt.IsoTrack_eta().at(i) - nt.Muon_eta().at(i_cand_muons_pf);
+      //	  float dphi = TVector2::Phi_mpi_pi(nt.IsoTrack_phi().at(i) - nt.Muon_phi().at(i_cand_muons_pf));
+      //	  float dr = TMath::Sqrt( deta*deta+dphi*dphi );
+      //	  if ( dr < mindr ){
+      //	    mindr = dr;
+      //	  }
+      //	}
+      //	if ( mindr > 0.02)
+      //	  extra_isotracks_lep.push_back(i);
+      //  }
+      //}
+      //vector<int> extra_isotracks_chh;
+      //for ( int i = 0; i < nt.nIsoTrack(); i++ ){
+      //  if ( nt.IsoTrack_isPFcand().at(i) && 
+      //	   nt.IsoTrack_pt().at(i) > 10. && abs(nt.IsoTrack_pdgId().at(i))==211 &&
+      //	   fabs(nt.IsoTrack_eta().at(i)) < 2.4 &&
+      //	   fabs(nt.IsoTrack_dz().at(i)) < 0.1 &&
+      //	   nt.IsoTrack_pfRelIso03_chg().at(i) < 0.1){
+      //	float mindr=1e9;
+      //    for ( auto i_cand_muons_pf : cand_muons_pf ){
+      //	  float deta = nt.IsoTrack_eta().at(i) - nt.Muon_eta().at(i_cand_muons_pf);
+      //	  float dphi = TVector2::Phi_mpi_pi(nt.IsoTrack_phi().at(i) - nt.Muon_phi().at(i_cand_muons_pf));
+      //	  float dr = TMath::Sqrt( deta*deta+dphi*dphi );
+      //	  if ( dr < mindr ){
+      //	    mindr = dr;
+      //	  }
+      //	}
+      //	if ( mindr > 0.02)
+      //	  extra_isotracks_chh.push_back(i);
+      //  }
+      //}
+
+      //Fill relevant histograms for extra electrons, muons
+      h_nExtra_muons_sel5->Fill(extra_muons.size(),weight*factor);
+      h_nExtra_electrons_sel5->Fill(extra_electrons.size(),weight*factor);
+      //h_nExtra_lepIsoTracks_sel5->Fill(extra_isotracks_lep.size(),weight*factor);
+      //h_nExtra_chhIsoTracks_sel5->Fill(extra_isotracks_chh.size(),weight*factor);
+
+      //if ( extra_muons.size() == 1 ) h_third_mu_pt_sel5->Fill(nt.Muon_pt().at(extra_muons[0]),weight*factor);
+      //if ( extra_electrons.size() == 1 ) h_first_el_pt_sel5->Fill(nt.Electron_pt().at(extra_electrons[0]),weight*factor);
+      //if ( extra_muons.size() > 1 ){
+      //     h_third_mu_pt_sel5->Fill(nt.Muon_pt().at(extra_muons[0]),weight*factor);
+      //	 h_fourth_mu_pt_sel5->Fill(nt.Muon_pt().at(extra_muons[1]),weight*factor); 
+      //}
+      //if ( extra_electrons.size() > 1 ){
+      //     h_first_el_pt_sel5->Fill(nt.Electron_pt().at(extra_electrons[0]),weight*factor);
+      //     h_second_el_pt_sel5->Fill(nt.Electron_pt().at(extra_electrons[1]),weight*factor);
+      //}
+ 
+      if ( extra_muons.size() > 0 || extra_electrons.size() > 0 ) continue;
+      h_cutflow->Fill(icutflow,weight*factor);
+      h_cutflow->GetXaxis()->SetBinLabel(icutflow+1,"Third lepton veto");
+      icutflow++;
+
+      //if ( extra_lepIsoTracks.size() > 0 || extra_isotracks_chh.size() > 0 ) continue;
+      //h_cutflow->Fill(icutflow,weight*factor);
+      //h_cutflow->GetXaxis()->SetBinLabel(icutflow+1,"IsoTrack veto");
+      //icutflow++;
+
+      vector<int> cand_bJets;
+      unsigned int nbtagDeepFlavB = 0;
+      //bool mu_jet_sep = true;
+      for ( unsigned int jet = 0; jet < nt.nJet(); jet++ ) {
+	float d_eta_1 = nt.Muon_eta().at(leadingMu_idx) - nt.Jet_eta().at(jet);
+	float d_eta_2 = nt.Muon_eta().at(subleadingMu_idx) - nt.Jet_eta().at(jet);
+	float d_phi_1 = TVector2::Phi_mpi_pi(nt.Muon_phi().at(leadingMu_idx) - nt.Jet_phi().at(jet));
+	float d_phi_2 = TVector2::Phi_mpi_pi(nt.Muon_phi().at(subleadingMu_idx) - nt.Jet_phi().at(jet));
+	float dr_jmu1 = TMath::Sqrt( d_eta_1*d_eta_1+d_phi_1*d_phi_1 );
+	float dr_jmu2 = TMath::Sqrt( d_eta_2*d_eta_2+d_phi_2*d_phi_2 );
+	// Reject jets if they are within dR = 0.4 of the candidate leptons
+	if ( dr_jmu1 < 0.4 || dr_jmu2 < 0.4 ) continue;
+	if ( nt.Jet_pt().at(jet) > 30 && nt.Jet_jetId().at(jet) > 0 && nt.Jet_btagDeepFlavB().at(jet) > 0.2783 ) // 0.0490 for loose, 0.7100 for tight
+	  {
+	    cand_bJets.push_back(jet);  // Medium DeepJet WP
+	    //h_btagDeepFlavB_sel6->Fill(nt.Jet_btagDeepFlavB().at(jet),weight*factor);
+	  }
+      }
+      h_nbtagDeepFlavB_sel6->Fill(cand_bJets.size(),weight*factor);
+      h_mll_pf_sel6->Fill(selectedPair_M,weight*factor);
+      if ( cand_bJets.size() < 1 ) continue;
+      h_cutflow->Fill(icutflow,weight*factor);
+      h_cutflow->GetXaxis()->SetBinLabel(icutflow+1,"At least 1 b-tag");
+      icutflow++;
+      h_mll_pf_sel7->Fill(selectedPair_M,weight*factor);
+      if ( selectedPair_M < 150 ) continue;
+      h_cutflow->Fill(icutflow,weight*factor);
+      h_cutflow->GetXaxis()->SetBinLabel(icutflow+1,"m(ll)>150 GeV");
+      icutflow++;
+
+      //Fill pT distributions for the bjets....
+      if ( cand_bJets.size() == 1 ){
+	h_bjet1_pt_sel8->Fill(nt.Jet_pt().at(cand_bJets[0]),weight*factor);
+      }
+
+      if ( cand_bJets.size() > 1 ){
+	h_bjet1_pt_sel8->Fill(nt.Jet_pt().at(cand_bJets[0]),weight*factor);
+	h_bjet2_pt_sel8->Fill(nt.Jet_pt().at(cand_bJets[1]),weight*factor);
+      }
+
+
+      //Construct mlb pairs from selected muon pair and candidate b jets
+      //float m_lb = 0;
+      vector<float> m_lb_vec;
+      for ( int bjet = 0; bjet < cand_bJets.size(); bjet++ ){
+	if ( bjet > 2 ) continue;
+	float m_mu1_b = (nt.Muon_p4().at(leadingMu_idx)+nt.Jet_p4().at(cand_bJets[bjet])).M();
+	float m_mu2_b = (nt.Muon_p4().at(subleadingMu_idx)+nt.Jet_p4().at(cand_bJets[bjet])).M();
+	m_lb_vec.push_back(m_mu1_b);
+	m_lb_vec.push_back(m_mu2_b);		  
+      }
              
 
-            float min_mlb = 1e9;
-            for ( int k = 0; k < m_lb_vec.size(); k++ ){
-                  if ( m_lb_vec[k] < min_mlb ){
-                       min_mlb = m_lb_vec[k];
-                  }
-            }
+      float min_mlb = 1e9;
+      for ( int k = 0; k < m_lb_vec.size(); k++ ){
+	if ( m_lb_vec[k] < min_mlb ){
+	  min_mlb = m_lb_vec[k];
+	}
+      }
 
-            h_met_pt_sel8->Fill(pfmet_pt,weight*factor);
-            h_met_phi_sel8->Fill(pfmet_phi,weight*factor);
-            h_mu1_trkRelIso_sel8->Fill(nt.Muon_tkRelIso().at(leadingMu_idx),weight*factor);
-            h_mu2_trkRelIso_sel8->Fill(nt.Muon_tkRelIso().at(subleadingMu_idx),weight*factor);
-            h_mll_pf_sel8->Fill(selectedPair_M,weight*factor); 	 
-            h_mu1_pt_sel8->Fill(nt.Muon_pt().at(leadingMu_idx),weight*factor);
-            h_mu2_pt_sel8->Fill(nt.Muon_pt().at(subleadingMu_idx),weight*factor);
-            h_min_mlb_sel8->Fill(min_mlb,weight*factor);
+      h_met_pt_sel8->Fill(pfmet_pt,weight*factor);
+      h_met_phi_sel8->Fill(pfmet_phi,weight*factor);
+      h_mu1_trkRelIso_sel8->Fill(nt.Muon_tkRelIso().at(leadingMu_idx),weight*factor);
+      h_mu2_trkRelIso_sel8->Fill(nt.Muon_tkRelIso().at(subleadingMu_idx),weight*factor);
+      h_mll_pf_sel8->Fill(selectedPair_M,weight*factor); 	 
+      h_mu1_pt_sel8->Fill(nt.Muon_pt().at(leadingMu_idx),weight*factor);
+      h_mu2_pt_sel8->Fill(nt.Muon_pt().at(subleadingMu_idx),weight*factor);
+      h_min_mlb_sel8->Fill(min_mlb,weight*factor);
             
-            if ( min_mlb < 175.0 ) continue;
-            h_cutflow->Fill(icutflow,weight*factor);
-	    h_cutflow->GetXaxis()->SetBinLabel(icutflow+1,"min m(lb)>175 GeV");
-            icutflow++;
-	    h_met_pt_sel9->Fill(pfmet_pt,weight*factor);
-	    h_met_phi_sel9->Fill(pfmet_phi,weight*factor);
-            h_mu1_trkRelIso_sel9->Fill(nt.Muon_tkRelIso().at(leadingMu_idx),weight*factor);
-            h_mu2_trkRelIso_sel9->Fill(nt.Muon_tkRelIso().at(subleadingMu_idx),weight*factor);
-            h_mll_pf_sel9->Fill(selectedPair_M,weight*factor); 	 
-            h_mu1_pt_sel9->Fill(nt.Muon_pt().at(leadingMu_idx),weight*factor);
-            h_mu2_pt_sel9->Fill(nt.Muon_pt().at(subleadingMu_idx),weight*factor);
-            h_min_mlb_sel9->Fill(min_mlb,weight*factor);
+      if ( min_mlb < 175.0 ) continue;
+      h_cutflow->Fill(icutflow,weight*factor);
+      h_cutflow->GetXaxis()->SetBinLabel(icutflow+1,"min m(lb)>175 GeV");
+      icutflow++;
+      h_met_pt_sel9->Fill(pfmet_pt,weight*factor);
+      h_met_phi_sel9->Fill(pfmet_phi,weight*factor);
+      h_mu1_trkRelIso_sel9->Fill(nt.Muon_tkRelIso().at(leadingMu_idx),weight*factor);
+      h_mu2_trkRelIso_sel9->Fill(nt.Muon_tkRelIso().at(subleadingMu_idx),weight*factor);
+      h_mll_pf_sel9->Fill(selectedPair_M,weight*factor); 	 
+      h_mu1_pt_sel9->Fill(nt.Muon_pt().at(leadingMu_idx),weight*factor);
+      h_mu2_pt_sel9->Fill(nt.Muon_pt().at(subleadingMu_idx),weight*factor);
+      h_min_mlb_sel9->Fill(min_mlb,weight*factor);
 
-        } // Event loop
+    } // Event loop
 
-        delete file;
+    delete file;
 
 
-    } // File loop
-    bar.finish();
+  } // File loop
+  bar.finish();
 
-    f1->Write();
-    f1->Close();
-    return 0;
+  f1->Write();
+  f1->Close();
+  return 0;
 }

--- a/cpp/ScanChain_Zp.C
+++ b/cpp/ScanChain_Zp.C
@@ -93,10 +93,10 @@ int ScanChain(TChain *ch, double genEventSumw, TString year, TString process) {
     // Modify the name of the output file to include arguments of ScanChain function (i.e. process, year, etc.)
     TFile* f1 = new TFile("temp_data/output_"+process+"_"+year+".root", "RECREATE");
     H1(cutflow,20,0,20);
-    H1(mll_pf_sel6,240,100,2500);
-    H1(mll_pf_sel7,240,100,2500);
-    H1(mll_pf_sel8,240,100,2500);
-    H1(mll_pf_sel9,240,100,2500);
+    H1(mll_pf_sel6,241,90,2500);
+    H1(mll_pf_sel7,241,90,2500);
+    H1(mll_pf_sel8,241,90,2500);
+    H1(mll_pf_sel9,241,90,2500);
     H1(mu1_pt_sel1,200,0,1000);
     H1(mu2_pt_sel1,200,0,1000);
     H1(mu1_pt_sel2,200,0,1000);

--- a/cpp/ScanChain_Zp.C
+++ b/cpp/ScanChain_Zp.C
@@ -126,10 +126,13 @@ int ScanChain(TChain *ch, double genEventSumw, TString year, TString process) {
     H1(met_phi_sel9,65,-3.25,3.25);
     H1(nExtra_muons_sel5,6,0,6);
     H1(nExtra_electrons_sel5,6,0,6);
-    H1(third_mu_pt_sel5,100,0,500);
-    H1(fourth_mu_pt_sel5,100,0,500);
-    H1(first_el_pt_sel5,100,0,500);
-    H1(second_el_pt_sel5,100,0,500);
+    H1(nExtra_lepIsoTracks_sel5,6,0,6);
+    H1(nExtra_chhIsoTracks_sel5,6,0,6);
+    //H1(third_mu_pt_sel5,100,0,500);
+    //H1(fourth_mu_pt_sel5,100,0,500);
+    //H1(first_el_pt_sel5,100,0,500);
+    //H1(second_el_pt_sel5,100,0,500);
+    //H1(dr_trigobj_sel3,50,0,0.5);
 
     int nEventsTotal = 0;
     int nEvents_more_leps = 0;
@@ -210,7 +213,7 @@ int ScanChain(TChain *ch, double genEventSumw, TString year, TString process) {
 	      bool mu_trk_and_global = ( nt.Muon_isGlobal().at(mu) && nt.Muon_isTracker().at(mu) );
 	      bool mu_id = ( nt.Muon_highPtId().at(mu) == 2 );
 	      bool mu_pt_pf = ( nt.Muon_pt().at(mu) > 53 && fabs(nt.Muon_eta().at(mu)) < 2.4 );
-	      bool mu_relIso = ( nt.Muon_tkRelIso().at(mu) < 0.1 );
+	      bool mu_relIso = ( nt.Muon_tkRelIso().at(mu) < 0.02 );
 	      
 	      if ( mu_trk_and_global && mu_id ){
 		nMu_id++;
@@ -266,7 +269,8 @@ int ScanChain(TChain *ch, double genEventSumw, TString year, TString process) {
                     float deta = nt.TrigObj_eta().at(n) - nt.Muon_eta().at(i_cand_muons_pf);
                     float dphi = TVector2::Phi_mpi_pi(nt.TrigObj_phi().at(n) - nt.Muon_phi().at(i_cand_muons_pf));
                     float dr = TMath::Sqrt( deta*deta+dphi*dphi );
-                    if ( dr < 0.1 ){
+		    //h_dr_trigobj_sel3->Fill(dr,weight*factor);
+                    if ( dr < 0.02 ){
                         muMatchedToTrigObj.push_back(true);
                         atLeastSelectedMu_matchedToTrigObj = true;
                     }
@@ -313,47 +317,95 @@ int ScanChain(TChain *ch, double genEventSumw, TString year, TString process) {
             // Muons
             vector<int> extra_muons;
             for ( int i = 0; i < nt.nMuon(); i++ ){
-                  if ( nt.Muon_pt().at(i) > 10. && 
-		       fabs(nt.Muon_eta().at(i)) < 2.4 &&
-		       nt.Muon_looseId().at(i) > 0 && 
-		       nt.Muon_dxy().at(i) < 0.2 && nt.Muon_dz().at(i) < 0.5 &&
-		       nt.Muon_miniPFRelIso_all().at(i) < 0.2 &&
-		       !( i == leadingMu_idx || i == subleadingMu_idx)){
-		    extra_muons.push_back(i);
-                  }
+	      if ( nt.Muon_pt().at(i) > 10. && 
+		   fabs(nt.Muon_eta().at(i)) < 2.4 &&
+		   nt.Muon_looseId().at(i) > 0 && 
+		   fabs(nt.Muon_dxy().at(i)) < 0.2 && fabs(nt.Muon_dz().at(i)) < 0.5 &&
+		   nt.Muon_miniPFRelIso_all().at(i) < 0.2 &&
+		   !( i == leadingMu_idx || i == subleadingMu_idx)){
+		extra_muons.push_back(i);
+	      }
             }
 
             // Electrons
             vector<int> extra_electrons;
-            for ( int k = 0; k < nt.nElectron(); k++ ){
-                  if ( nt.Electron_pt().at(k) > 10. &&
-		       fabs(nt.Electron_eta().at(k)) < 2.4 &&
-		       nt.Electron_cutBased().at(k) > 0 && 
-		       nt.Electron_miniPFRelIso_all().at(k) < 0.1){
-		    extra_electrons.push_back(k);
-		  }
+            for ( int i = 0; i < nt.nElectron(); i++ ){
+	      if ( nt.Electron_pt().at(i) > 10. &&
+		   fabs(nt.Electron_eta().at(i)) < 2.4 &&
+		   nt.Electron_cutBased().at(i) > 0 && 
+		   nt.Electron_miniPFRelIso_all().at(i) < 0.1){
+		extra_electrons.push_back(i);
+	      }
             }
+
+            //// IsoTracks
+            //vector<int> extra_isotracks_lep;
+            //for ( int i = 0; i < nt.nIsoTrack(); i++ ){
+	    //  if ( nt.IsoTrack_isPFcand().at(i) && 
+	    //	   nt.IsoTrack_pt().at(i) > 5. && (abs(nt.IsoTrack_pdgId().at(i))==11 || (abs(nt.IsoTrack_pdgId().at(i))==13)) &&
+	    //	   fabs(nt.IsoTrack_eta().at(i)) < 2.4 &&
+	    //	   fabs(nt.IsoTrack_dz().at(i)) < 0.1 &&
+	    //	   nt.IsoTrack_pfRelIso03_chg().at(i) < 0.2){
+	    //	float mindr=1e9;
+            //    for ( auto i_cand_muons_pf : cand_muons_pf ){
+	    //	  float deta = nt.IsoTrack_eta().at(i) - nt.Muon_eta().at(i_cand_muons_pf);
+	    //	  float dphi = TVector2::Phi_mpi_pi(nt.IsoTrack_phi().at(i) - nt.Muon_phi().at(i_cand_muons_pf));
+	    //	  float dr = TMath::Sqrt( deta*deta+dphi*dphi );
+	    //	  if ( dr < mindr ){
+	    //	    mindr = dr;
+	    //	  }
+	    //	}
+	    //	if ( mindr > 0.02)
+	    //	  extra_isotracks_lep.push_back(i);
+	    //  }
+	    //}
+            //vector<int> extra_isotracks_chh;
+            //for ( int i = 0; i < nt.nIsoTrack(); i++ ){
+	    //  if ( nt.IsoTrack_isPFcand().at(i) && 
+	    //	   nt.IsoTrack_pt().at(i) > 10. && abs(nt.IsoTrack_pdgId().at(i))==211 &&
+	    //	   fabs(nt.IsoTrack_eta().at(i)) < 2.4 &&
+	    //	   fabs(nt.IsoTrack_dz().at(i)) < 0.1 &&
+	    //	   nt.IsoTrack_pfRelIso03_chg().at(i) < 0.1){
+	    //	float mindr=1e9;
+            //    for ( auto i_cand_muons_pf : cand_muons_pf ){
+	    //	  float deta = nt.IsoTrack_eta().at(i) - nt.Muon_eta().at(i_cand_muons_pf);
+	    //	  float dphi = TVector2::Phi_mpi_pi(nt.IsoTrack_phi().at(i) - nt.Muon_phi().at(i_cand_muons_pf));
+	    //	  float dr = TMath::Sqrt( deta*deta+dphi*dphi );
+	    //	  if ( dr < mindr ){
+	    //	    mindr = dr;
+	    //	  }
+	    //	}
+	    //	if ( mindr > 0.02)
+	    //	  extra_isotracks_chh.push_back(i);
+	    //  }
+            //}
 
             //Fill relevant histograms for extra electrons, muons
             h_nExtra_muons_sel5->Fill(extra_muons.size(),weight*factor);
             h_nExtra_electrons_sel5->Fill(extra_electrons.size(),weight*factor);
+            //h_nExtra_lepIsoTracks_sel5->Fill(extra_isotracks_lep.size(),weight*factor);
+            //h_nExtra_chhIsoTracks_sel5->Fill(extra_isotracks_chh.size(),weight*factor);
 
-            if ( extra_muons.size() == 1 ) h_third_mu_pt_sel5->Fill(nt.Muon_pt().at(extra_muons[0]),weight*factor);
-            if ( extra_electrons.size() == 1 ) h_first_el_pt_sel5->Fill(nt.Electron_pt().at(extra_electrons[0]),weight*factor);
-            if ( extra_muons.size() > 1 ){
-                 h_third_mu_pt_sel5->Fill(nt.Muon_pt().at(extra_muons[0]),weight*factor);
-		 h_fourth_mu_pt_sel5->Fill(nt.Muon_pt().at(extra_muons[1]),weight*factor); 
-            }
-            if ( extra_electrons.size() > 1 ){
-                 h_first_el_pt_sel5->Fill(nt.Electron_pt().at(extra_electrons[0]),weight*factor);
-                 h_second_el_pt_sel5->Fill(nt.Electron_pt().at(extra_electrons[1]),weight*factor);
-            }
+            //if ( extra_muons.size() == 1 ) h_third_mu_pt_sel5->Fill(nt.Muon_pt().at(extra_muons[0]),weight*factor);
+            //if ( extra_electrons.size() == 1 ) h_first_el_pt_sel5->Fill(nt.Electron_pt().at(extra_electrons[0]),weight*factor);
+            //if ( extra_muons.size() > 1 ){
+            //     h_third_mu_pt_sel5->Fill(nt.Muon_pt().at(extra_muons[0]),weight*factor);
+	    //	 h_fourth_mu_pt_sel5->Fill(nt.Muon_pt().at(extra_muons[1]),weight*factor); 
+            //}
+            //if ( extra_electrons.size() > 1 ){
+            //     h_first_el_pt_sel5->Fill(nt.Electron_pt().at(extra_electrons[0]),weight*factor);
+            //     h_second_el_pt_sel5->Fill(nt.Electron_pt().at(extra_electrons[1]),weight*factor);
+            //}
  
-
             if ( extra_muons.size() > 0 || extra_electrons.size() > 0 ) continue;
             h_cutflow->Fill(icutflow,weight*factor);
 	    h_cutflow->GetXaxis()->SetBinLabel(icutflow+1,"Third lepton veto");
             icutflow++;
+
+            //if ( extra_lepIsoTracks.size() > 0 || extra_isotracks_chh.size() > 0 ) continue;
+            //h_cutflow->Fill(icutflow,weight*factor);
+	    //h_cutflow->GetXaxis()->SetBinLabel(icutflow+1,"IsoTrack veto");
+            //icutflow++;
 
             vector<int> cand_bJets;
             unsigned int nbtagDeepFlavB = 0;

--- a/cpp/ScanChain_Zp.C
+++ b/cpp/ScanChain_Zp.C
@@ -342,41 +342,43 @@ int ScanChain(TChain *ch, double genEventSumw, TString year, TString process) {
       vector<int> extra_isotracks_lep;
       for ( int i = 0; i < nt.nIsoTrack(); i++ ){
         if ( nt.IsoTrack_isPFcand().at(i) && 
-      	   nt.IsoTrack_pt().at(i) > 5. && (abs(nt.IsoTrack_pdgId().at(i))==11 || (abs(nt.IsoTrack_pdgId().at(i))==13)) &&
-      	   fabs(nt.IsoTrack_eta().at(i)) < 2.4 &&
-      	   fabs(nt.IsoTrack_dz().at(i)) < 0.1 &&
-      	   nt.IsoTrack_pfRelIso03_chg().at(i) < 0.2){
-      	float mindr=1e9;
+	     nt.IsoTrack_pt().at(i) > 5. && (abs(nt.IsoTrack_pdgId().at(i))==11 || (abs(nt.IsoTrack_pdgId().at(i))==13)) &&
+	     fabs(nt.IsoTrack_eta().at(i)) < 2.4 &&
+	     fabs(nt.IsoTrack_dz().at(i)) < 0.1 &&
+	     nt.IsoTrack_pfRelIso03_chg().at(i) < 0.2){
+	  float mindr=1e9;
           for ( auto i_cand_muons_pf : cand_muons_pf ){
-      	  float deta = nt.IsoTrack_eta().at(i) - nt.Muon_eta().at(i_cand_muons_pf);
-      	  float dphi = TVector2::Phi_mpi_pi(nt.IsoTrack_phi().at(i) - nt.Muon_phi().at(i_cand_muons_pf));
-      	  float dr = TMath::Sqrt( deta*deta+dphi*dphi );
-      	  if ( dr < mindr ){
-      	    mindr = dr;
-      	  }
-      	}
-      	if ( mindr > 0.02)
-      	  extra_isotracks_lep.push_back(i);
+	    if (i_cand_muons_pf!=leadingMu_idx && i_cand_muons_pf!=subleadingMu_idx) continue;
+	    float deta = nt.IsoTrack_eta().at(i) - nt.Muon_eta().at(i_cand_muons_pf);
+	    float dphi = TVector2::Phi_mpi_pi(nt.IsoTrack_phi().at(i) - nt.Muon_phi().at(i_cand_muons_pf));
+	    float dr = TMath::Sqrt( deta*deta+dphi*dphi );
+	    if ( dr < mindr ){
+	      mindr = dr;
+	    }
+	  }
+	  if ( mindr > 0.02)
+	    extra_isotracks_lep.push_back(i);
         }
       }
       vector<int> extra_isotracks_chh;
       for ( int i = 0; i < nt.nIsoTrack(); i++ ){
         if ( nt.IsoTrack_isPFcand().at(i) && 
-      	   nt.IsoTrack_pt().at(i) > 10. && abs(nt.IsoTrack_pdgId().at(i))==211 &&
-      	   fabs(nt.IsoTrack_eta().at(i)) < 2.4 &&
-      	   fabs(nt.IsoTrack_dz().at(i)) < 0.1 &&
-      	   nt.IsoTrack_pfRelIso03_chg().at(i) < 0.1){
-      	float mindr=1e9;
+	     nt.IsoTrack_pt().at(i) > 10. && abs(nt.IsoTrack_pdgId().at(i))==211 &&
+	     fabs(nt.IsoTrack_eta().at(i)) < 2.4 &&
+	     fabs(nt.IsoTrack_dz().at(i)) < 0.1 &&
+	     nt.IsoTrack_pfRelIso03_chg().at(i) < 0.1){
+	  float mindr=1e9;
           for ( auto i_cand_muons_pf : cand_muons_pf ){
-      	  float deta = nt.IsoTrack_eta().at(i) - nt.Muon_eta().at(i_cand_muons_pf);
-      	  float dphi = TVector2::Phi_mpi_pi(nt.IsoTrack_phi().at(i) - nt.Muon_phi().at(i_cand_muons_pf));
-      	  float dr = TMath::Sqrt( deta*deta+dphi*dphi );
-      	  if ( dr < mindr ){
-      	    mindr = dr;
-      	  }
-      	}
-      	if ( mindr > 0.02)
-      	  extra_isotracks_chh.push_back(i);
+	    if (i_cand_muons_pf!=leadingMu_idx && i_cand_muons_pf!=subleadingMu_idx) continue;
+	    float deta = nt.IsoTrack_eta().at(i) - nt.Muon_eta().at(i_cand_muons_pf);
+	    float dphi = TVector2::Phi_mpi_pi(nt.IsoTrack_phi().at(i) - nt.Muon_phi().at(i_cand_muons_pf));
+	    float dr = TMath::Sqrt( deta*deta+dphi*dphi );
+	    if ( dr < mindr ){
+	      mindr = dr;
+	    }
+	  }
+	  if ( mindr > 0.02)
+	    extra_isotracks_chh.push_back(i);
         }
       }
 

--- a/cpp/ScanChain_Zp.C
+++ b/cpp/ScanChain_Zp.C
@@ -173,9 +173,9 @@ int ScanChain(TChain *ch, double genEventSumw, TString year, TString process) {
       std::pair<double,double> pfmet = METXYCorr_Met_MetPhi(nt.MET_pt(), nt.MET_phi(), runnb, year, isMC, npv, true, false);
       double pfmet_pt  = pfmet.first;
       double pfmet_phi = pfmet.second;
-      //std::pair<double,double> puppimet = METXYCorr_Met_MetPhi(nt.PuppiMET_pt(), nt.PuppiMET_phi(), runnb, year, isMC, npv, true, true);
-      //double puppimet_pt  = puppimet.first;
-      //double puppimet_phi = puppimet.second;
+      std::pair<double,double> puppimet = METXYCorr_Met_MetPhi(nt.PuppiMET_pt(), nt.PuppiMET_phi(), runnb, year, isMC, npv, true, true);
+      double puppimet_pt  = puppimet.first;
+      double puppimet_phi = puppimet.second;
 
       // Define vector of muon candidate indices here.....
       vector<int> cand_muons_pf_id;
@@ -338,53 +338,53 @@ int ScanChain(TChain *ch, double genEventSumw, TString year, TString process) {
 	}
       }
 
-      //// IsoTracks
-      //vector<int> extra_isotracks_lep;
-      //for ( int i = 0; i < nt.nIsoTrack(); i++ ){
-      //  if ( nt.IsoTrack_isPFcand().at(i) && 
-      //	   nt.IsoTrack_pt().at(i) > 5. && (abs(nt.IsoTrack_pdgId().at(i))==11 || (abs(nt.IsoTrack_pdgId().at(i))==13)) &&
-      //	   fabs(nt.IsoTrack_eta().at(i)) < 2.4 &&
-      //	   fabs(nt.IsoTrack_dz().at(i)) < 0.1 &&
-      //	   nt.IsoTrack_pfRelIso03_chg().at(i) < 0.2){
-      //	float mindr=1e9;
-      //    for ( auto i_cand_muons_pf : cand_muons_pf ){
-      //	  float deta = nt.IsoTrack_eta().at(i) - nt.Muon_eta().at(i_cand_muons_pf);
-      //	  float dphi = TVector2::Phi_mpi_pi(nt.IsoTrack_phi().at(i) - nt.Muon_phi().at(i_cand_muons_pf));
-      //	  float dr = TMath::Sqrt( deta*deta+dphi*dphi );
-      //	  if ( dr < mindr ){
-      //	    mindr = dr;
-      //	  }
-      //	}
-      //	if ( mindr > 0.02)
-      //	  extra_isotracks_lep.push_back(i);
-      //  }
-      //}
-      //vector<int> extra_isotracks_chh;
-      //for ( int i = 0; i < nt.nIsoTrack(); i++ ){
-      //  if ( nt.IsoTrack_isPFcand().at(i) && 
-      //	   nt.IsoTrack_pt().at(i) > 10. && abs(nt.IsoTrack_pdgId().at(i))==211 &&
-      //	   fabs(nt.IsoTrack_eta().at(i)) < 2.4 &&
-      //	   fabs(nt.IsoTrack_dz().at(i)) < 0.1 &&
-      //	   nt.IsoTrack_pfRelIso03_chg().at(i) < 0.1){
-      //	float mindr=1e9;
-      //    for ( auto i_cand_muons_pf : cand_muons_pf ){
-      //	  float deta = nt.IsoTrack_eta().at(i) - nt.Muon_eta().at(i_cand_muons_pf);
-      //	  float dphi = TVector2::Phi_mpi_pi(nt.IsoTrack_phi().at(i) - nt.Muon_phi().at(i_cand_muons_pf));
-      //	  float dr = TMath::Sqrt( deta*deta+dphi*dphi );
-      //	  if ( dr < mindr ){
-      //	    mindr = dr;
-      //	  }
-      //	}
-      //	if ( mindr > 0.02)
-      //	  extra_isotracks_chh.push_back(i);
-      //  }
-      //}
+      // IsoTracks
+      vector<int> extra_isotracks_lep;
+      for ( int i = 0; i < nt.nIsoTrack(); i++ ){
+        if ( nt.IsoTrack_isPFcand().at(i) && 
+      	   nt.IsoTrack_pt().at(i) > 5. && (abs(nt.IsoTrack_pdgId().at(i))==11 || (abs(nt.IsoTrack_pdgId().at(i))==13)) &&
+      	   fabs(nt.IsoTrack_eta().at(i)) < 2.4 &&
+      	   fabs(nt.IsoTrack_dz().at(i)) < 0.1 &&
+      	   nt.IsoTrack_pfRelIso03_chg().at(i) < 0.2){
+      	float mindr=1e9;
+          for ( auto i_cand_muons_pf : cand_muons_pf ){
+      	  float deta = nt.IsoTrack_eta().at(i) - nt.Muon_eta().at(i_cand_muons_pf);
+      	  float dphi = TVector2::Phi_mpi_pi(nt.IsoTrack_phi().at(i) - nt.Muon_phi().at(i_cand_muons_pf));
+      	  float dr = TMath::Sqrt( deta*deta+dphi*dphi );
+      	  if ( dr < mindr ){
+      	    mindr = dr;
+      	  }
+      	}
+      	if ( mindr > 0.02)
+      	  extra_isotracks_lep.push_back(i);
+        }
+      }
+      vector<int> extra_isotracks_chh;
+      for ( int i = 0; i < nt.nIsoTrack(); i++ ){
+        if ( nt.IsoTrack_isPFcand().at(i) && 
+      	   nt.IsoTrack_pt().at(i) > 10. && abs(nt.IsoTrack_pdgId().at(i))==211 &&
+      	   fabs(nt.IsoTrack_eta().at(i)) < 2.4 &&
+      	   fabs(nt.IsoTrack_dz().at(i)) < 0.1 &&
+      	   nt.IsoTrack_pfRelIso03_chg().at(i) < 0.1){
+      	float mindr=1e9;
+          for ( auto i_cand_muons_pf : cand_muons_pf ){
+      	  float deta = nt.IsoTrack_eta().at(i) - nt.Muon_eta().at(i_cand_muons_pf);
+      	  float dphi = TVector2::Phi_mpi_pi(nt.IsoTrack_phi().at(i) - nt.Muon_phi().at(i_cand_muons_pf));
+      	  float dr = TMath::Sqrt( deta*deta+dphi*dphi );
+      	  if ( dr < mindr ){
+      	    mindr = dr;
+      	  }
+      	}
+      	if ( mindr > 0.02)
+      	  extra_isotracks_chh.push_back(i);
+        }
+      }
 
       //Fill relevant histograms for extra electrons, muons
       h_nExtra_muons_sel5->Fill(extra_muons.size(),weight*factor);
       h_nExtra_electrons_sel5->Fill(extra_electrons.size(),weight*factor);
-      //h_nExtra_lepIsoTracks_sel5->Fill(extra_isotracks_lep.size(),weight*factor);
-      //h_nExtra_chhIsoTracks_sel5->Fill(extra_isotracks_chh.size(),weight*factor);
+      h_nExtra_lepIsoTracks_sel5->Fill(extra_isotracks_lep.size(),weight*factor);
+      h_nExtra_chhIsoTracks_sel5->Fill(extra_isotracks_chh.size(),weight*factor);
 
       //if ( extra_muons.size() == 1 ) h_third_mu_pt_sel5->Fill(nt.Muon_pt().at(extra_muons[0]),weight*factor);
       //if ( extra_electrons.size() == 1 ) h_first_el_pt_sel5->Fill(nt.Electron_pt().at(extra_electrons[0]),weight*factor);
@@ -402,10 +402,10 @@ int ScanChain(TChain *ch, double genEventSumw, TString year, TString process) {
       h_cutflow->GetXaxis()->SetBinLabel(icutflow+1,"Third lepton veto");
       icutflow++;
 
-      //if ( extra_lepIsoTracks.size() > 0 || extra_isotracks_chh.size() > 0 ) continue;
-      //h_cutflow->Fill(icutflow,weight*factor);
-      //h_cutflow->GetXaxis()->SetBinLabel(icutflow+1,"IsoTrack veto");
-      //icutflow++;
+      if ( extra_isotracks_lep.size() > 0 || extra_isotracks_chh.size() > 0 ) continue;
+      h_cutflow->Fill(icutflow,weight*factor);
+      h_cutflow->GetXaxis()->SetBinLabel(icutflow+1,"IsoTrack veto");
+      icutflow++;
 
       vector<int> cand_bJets;
       unsigned int nbtagDeepFlavB = 0;

--- a/cpp/doAll_Zp.C
+++ b/cpp/doAll_Zp.C
@@ -60,87 +60,87 @@
   TChain *ch_ZToMuMu_6000_Inf = new TChain("Events");
   TChain *chaux_ZToMuMu_6000_Inf = new TChain("Runs");
 
-  TString baseDir = "/ceph/cms/store/user/evourlio/skimOutput/skim2mu_1muPt50_1Mll100";
-  TString baseSignalDir = "/ceph/cms/store/user/evourlio/skimOutput/skim2mu_1muPt50_1Mll100_PrivSignal";
+  TString baseDir = "/ceph/cms/store/user/evourlio/skimOutput/skim2mu_1muPt50_1Mll100_allBranches";
+  TString baseSignalDir = baseDir;
   // Files to be looped over
-  ch->Add(baseDir+"/TTTo2L2Nu_TuneCP5_13TeV-powheg-pythia8_RunIISummer20UL18NanoAODv9-106X_upgrade2018_realistic_v16_L1v1-v1_NANOAODSIM_skim2mu_1muPt50_1Mll100/merged/merged.root");
-  chaux->Add(baseDir+"/TTTo2L2Nu_TuneCP5_13TeV-powheg-pythia8_RunIISummer20UL18NanoAODv9-106X_upgrade2018_realistic_v16_L1v1-v1_NANOAODSIM_skim2mu_1muPt50_1Mll100/merged/merged.root");
+  ch->Add(baseDir+"/TTTo2L2Nu_TuneCP5_13TeV-powheg-pythia8_RunIISummer20UL18NanoAODv9-106X_upgrade2018_realistic_v16_L1v1-v1_NANOAODSIM_skim2mu_1muPt50_1Mll100_allBranches/merged/merged.root");
+  chaux->Add(baseDir+"/TTTo2L2Nu_TuneCP5_13TeV-powheg-pythia8_RunIISummer20UL18NanoAODv9-106X_upgrade2018_realistic_v16_L1v1-v1_NANOAODSIM_skim2mu_1muPt50_1Mll100_allBranches/merged/merged.root");
   ScanChain(ch,getSumOfGenEventSumw(chaux),"2018","ttbar");
 
-  //ch1->Add(baseDir+"/DYJetsToLL_M-50_TuneCP5_13TeV-amcatnloFXFX-pythia8_RunIISummer20UL18NanoAODv9-106X_upgrade2018_realistic_v16_L1v1-v2_NANOAODSIM_skim2mu_1muPt50_1Mll100/merged/merged.root");
-  //ch1aux->Add(baseDir+"/DYJetsToLL_M-50_TuneCP5_13TeV-amcatnloFXFX-pythia8_RunIISummer20UL18NanoAODv9-106X_upgrade2018_realistic_v16_L1v1-v2_NANOAODSIM_skim2mu_1muPt50_1Mll100/merged/merged.root");
+  //ch1->Add(baseDir+"/DYJetsToLL_M-50_TuneCP5_13TeV-amcatnloFXFX-pythia8_RunIISummer20UL18NanoAODv9-106X_upgrade2018_realistic_v16_L1v1-v2_NANOAODSIM_skim2mu_1muPt50_1Mll100_allBranches/merged/merged.root");
+  //ch1aux->Add(baseDir+"/DYJetsToLL_M-50_TuneCP5_13TeV-amcatnloFXFX-pythia8_RunIISummer20UL18NanoAODv9-106X_upgrade2018_realistic_v16_L1v1-v2_NANOAODSIM_skim2mu_1muPt50_1Mll100_allBranches/merged/merged.root");
   //ScanChain(ch1,getSumOfGenEventSumw(ch1aux),"2018","DY");
 
-  ch_ZToMuMu_50_120->Add(baseDir+"/ZToMuMu_NNPDF31_TuneCP5_13TeV-powheg-pythia8_M_50_120_RunIISummer19UL18NanoAOD-106X_upgrade2018_realistic_v11_L1v1-v1_NANOAODSIM_skim2mu_1muPt50_1Mll100/merged/merged.root");
-  chaux_ZToMuMu_50_120->Add(baseDir+"/ZToMuMu_NNPDF31_TuneCP5_13TeV-powheg-pythia8_M_50_120_RunIISummer19UL18NanoAOD-106X_upgrade2018_realistic_v11_L1v1-v1_NANOAODSIM_skim2mu_1muPt50_1Mll100/merged/merged.root");
+  ch_ZToMuMu_50_120->Add(baseDir+"/ZToMuMu_NNPDF31_TuneCP5_13TeV-powheg-pythia8_M_50_120_RunIISummer19UL18NanoAOD-106X_upgrade2018_realistic_v11_L1v1-v1_NANOAODSIM_skim2mu_1muPt50_1Mll100_allBranches/merged/merged.root");
+  chaux_ZToMuMu_50_120->Add(baseDir+"/ZToMuMu_NNPDF31_TuneCP5_13TeV-powheg-pythia8_M_50_120_RunIISummer19UL18NanoAOD-106X_upgrade2018_realistic_v11_L1v1-v1_NANOAODSIM_skim2mu_1muPt50_1Mll100_allBranches/merged/merged.root");
   ScanChain(ch_ZToMuMu_50_120,getSumOfGenEventSumw(chaux_ZToMuMu_50_120,true),"2018","ZToMuMu_50_120");
 
-  ch_ZToMuMu_120_200->Add(baseDir+"/ZToMuMu_NNPDF31_TuneCP5_13TeV-powheg-pythia8_M_120_200_RunIISummer19UL18NanoAOD-106X_upgrade2018_realistic_v11_L1v1-v2_NANOAODSIM_skim2mu_1muPt50_1Mll100/merged/merged.root");
-  chaux_ZToMuMu_120_200->Add(baseDir+"/ZToMuMu_NNPDF31_TuneCP5_13TeV-powheg-pythia8_M_120_200_RunIISummer19UL18NanoAOD-106X_upgrade2018_realistic_v11_L1v1-v2_NANOAODSIM_skim2mu_1muPt50_1Mll100/merged/merged.root");
+  ch_ZToMuMu_120_200->Add(baseDir+"/ZToMuMu_NNPDF31_TuneCP5_13TeV-powheg-pythia8_M_120_200_RunIISummer19UL18NanoAOD-106X_upgrade2018_realistic_v11_L1v1-v2_NANOAODSIM_skim2mu_1muPt50_1Mll100_allBranches/merged/merged.root");
+  chaux_ZToMuMu_120_200->Add(baseDir+"/ZToMuMu_NNPDF31_TuneCP5_13TeV-powheg-pythia8_M_120_200_RunIISummer19UL18NanoAOD-106X_upgrade2018_realistic_v11_L1v1-v2_NANOAODSIM_skim2mu_1muPt50_1Mll100_allBranches/merged/merged.root");
   ScanChain(ch_ZToMuMu_120_200,getSumOfGenEventSumw(chaux_ZToMuMu_120_200,true),"2018","ZToMuMu_120_200");
 
-  ch_ZToMuMu_200_400->Add(baseDir+"/ZToMuMu_NNPDF31_TuneCP5_13TeV-powheg-pythia8_M_200_400_RunIISummer19UL18NanoAOD-106X_upgrade2018_realistic_v11_L1v1-v1_NANOAODSIM_skim2mu_1muPt50_1Mll100/merged/merged.root");
-  chaux_ZToMuMu_200_400->Add(baseDir+"/ZToMuMu_NNPDF31_TuneCP5_13TeV-powheg-pythia8_M_200_400_RunIISummer19UL18NanoAOD-106X_upgrade2018_realistic_v11_L1v1-v1_NANOAODSIM_skim2mu_1muPt50_1Mll100/merged/merged.root");
+  ch_ZToMuMu_200_400->Add(baseDir+"/ZToMuMu_NNPDF31_TuneCP5_13TeV-powheg-pythia8_M_200_400_RunIISummer19UL18NanoAOD-106X_upgrade2018_realistic_v11_L1v1-v1_NANOAODSIM_skim2mu_1muPt50_1Mll100_allBranches/merged/merged.root");
+  chaux_ZToMuMu_200_400->Add(baseDir+"/ZToMuMu_NNPDF31_TuneCP5_13TeV-powheg-pythia8_M_200_400_RunIISummer19UL18NanoAOD-106X_upgrade2018_realistic_v11_L1v1-v1_NANOAODSIM_skim2mu_1muPt50_1Mll100_allBranches/merged/merged.root");
   ScanChain(ch_ZToMuMu_200_400,getSumOfGenEventSumw(chaux_ZToMuMu_200_400,true),"2018","ZToMuMu_200_400");
 
-  ch_ZToMuMu_400_800->Add(baseDir+"/ZToMuMu_NNPDF31_TuneCP5_13TeV-powheg-pythia8_M_400_800_RunIISummer19UL18NanoAOD-106X_upgrade2018_realistic_v11_L1v1-v2_NANOAODSIM_skim2mu_1muPt50_1Mll100/merged/merged.root");
-  chaux_ZToMuMu_400_800->Add(baseDir+"/ZToMuMu_NNPDF31_TuneCP5_13TeV-powheg-pythia8_M_400_800_RunIISummer19UL18NanoAOD-106X_upgrade2018_realistic_v11_L1v1-v2_NANOAODSIM_skim2mu_1muPt50_1Mll100/merged/merged.root");
+  ch_ZToMuMu_400_800->Add(baseDir+"/ZToMuMu_NNPDF31_TuneCP5_13TeV-powheg-pythia8_M_400_800_RunIISummer19UL18NanoAOD-106X_upgrade2018_realistic_v11_L1v1-v2_NANOAODSIM_skim2mu_1muPt50_1Mll100_allBranches/merged/merged.root");
+  chaux_ZToMuMu_400_800->Add(baseDir+"/ZToMuMu_NNPDF31_TuneCP5_13TeV-powheg-pythia8_M_400_800_RunIISummer19UL18NanoAOD-106X_upgrade2018_realistic_v11_L1v1-v2_NANOAODSIM_skim2mu_1muPt50_1Mll100_allBranches/merged/merged.root");
   ScanChain(ch_ZToMuMu_400_800,getSumOfGenEventSumw(chaux_ZToMuMu_400_800,true),"2018","ZToMuMu_400_800");
 
-  ch_ZToMuMu_800_1400->Add(baseDir+"/ZToMuMu_NNPDF31_TuneCP5_13TeV-powheg-pythia8_M_800_1400_RunIISummer19UL18NanoAOD-106X_upgrade2018_realistic_v11_L1v1-v2_NANOAODSIM_skim2mu_1muPt50_1Mll100/merged/merged.root");
-  chaux_ZToMuMu_800_1400->Add(baseDir+"/ZToMuMu_NNPDF31_TuneCP5_13TeV-powheg-pythia8_M_800_1400_RunIISummer19UL18NanoAOD-106X_upgrade2018_realistic_v11_L1v1-v2_NANOAODSIM_skim2mu_1muPt50_1Mll100/merged/merged.root");
+  ch_ZToMuMu_800_1400->Add(baseDir+"/ZToMuMu_NNPDF31_TuneCP5_13TeV-powheg-pythia8_M_800_1400_RunIISummer19UL18NanoAOD-106X_upgrade2018_realistic_v11_L1v1-v2_NANOAODSIM_skim2mu_1muPt50_1Mll100_allBranches/merged/merged.root");
+  chaux_ZToMuMu_800_1400->Add(baseDir+"/ZToMuMu_NNPDF31_TuneCP5_13TeV-powheg-pythia8_M_800_1400_RunIISummer19UL18NanoAOD-106X_upgrade2018_realistic_v11_L1v1-v2_NANOAODSIM_skim2mu_1muPt50_1Mll100_allBranches/merged/merged.root");
   ScanChain(ch_ZToMuMu_800_1400,getSumOfGenEventSumw(chaux_ZToMuMu_800_1400,true),"2018","ZToMuMu_800_1400");
 
-  ch_ZToMuMu_1400_2300->Add(baseDir+"/ZToMuMu_NNPDF31_TuneCP5_13TeV-powheg-pythia8_M_1400_2300_RunIISummer19UL18NanoAOD-106X_upgrade2018_realistic_v11_L1v1-v2_NANOAODSIM_skim2mu_1muPt50_1Mll100/merged/merged.root");
-  chaux_ZToMuMu_1400_2300->Add(baseDir+"/ZToMuMu_NNPDF31_TuneCP5_13TeV-powheg-pythia8_M_1400_2300_RunIISummer19UL18NanoAOD-106X_upgrade2018_realistic_v11_L1v1-v2_NANOAODSIM_skim2mu_1muPt50_1Mll100/merged/merged.root");
+  ch_ZToMuMu_1400_2300->Add(baseDir+"/ZToMuMu_NNPDF31_TuneCP5_13TeV-powheg-pythia8_M_1400_2300_RunIISummer19UL18NanoAOD-106X_upgrade2018_realistic_v11_L1v1-v2_NANOAODSIM_skim2mu_1muPt50_1Mll100_allBranches/merged/merged.root");
+  chaux_ZToMuMu_1400_2300->Add(baseDir+"/ZToMuMu_NNPDF31_TuneCP5_13TeV-powheg-pythia8_M_1400_2300_RunIISummer19UL18NanoAOD-106X_upgrade2018_realistic_v11_L1v1-v2_NANOAODSIM_skim2mu_1muPt50_1Mll100_allBranches/merged/merged.root");
   ScanChain(ch_ZToMuMu_1400_2300,getSumOfGenEventSumw(chaux_ZToMuMu_1400_2300,true),"2018","ZToMuMu_1400_2300");
 
-  ch_ZToMuMu_2300_3500->Add(baseDir+"/ZToMuMu_NNPDF31_TuneCP5_13TeV-powheg-pythia8_M_2300_3500_RunIISummer19UL18NanoAOD-106X_upgrade2018_realistic_v11_L1v1-v2_NANOAODSIM_skim2mu_1muPt50_1Mll100/merged/merged.root");
-  chaux_ZToMuMu_2300_3500->Add(baseDir+"/ZToMuMu_NNPDF31_TuneCP5_13TeV-powheg-pythia8_M_2300_3500_RunIISummer19UL18NanoAOD-106X_upgrade2018_realistic_v11_L1v1-v2_NANOAODSIM_skim2mu_1muPt50_1Mll100/merged/merged.root");
+  ch_ZToMuMu_2300_3500->Add(baseDir+"/ZToMuMu_NNPDF31_TuneCP5_13TeV-powheg-pythia8_M_2300_3500_RunIISummer19UL18NanoAOD-106X_upgrade2018_realistic_v11_L1v1-v2_NANOAODSIM_skim2mu_1muPt50_1Mll100_allBranches/merged/merged.root");
+  chaux_ZToMuMu_2300_3500->Add(baseDir+"/ZToMuMu_NNPDF31_TuneCP5_13TeV-powheg-pythia8_M_2300_3500_RunIISummer19UL18NanoAOD-106X_upgrade2018_realistic_v11_L1v1-v2_NANOAODSIM_skim2mu_1muPt50_1Mll100_allBranches/merged/merged.root");
   ScanChain(ch_ZToMuMu_2300_3500,getSumOfGenEventSumw(chaux_ZToMuMu_2300_3500,true),"2018","ZToMuMu_2300_3500");
 
-  ch_ZToMuMu_3500_4500->Add(baseDir+"/ZToMuMu_NNPDF31_TuneCP5_13TeV-powheg-pythia8_M_3500_4500_RunIISummer19UL18NanoAOD-106X_upgrade2018_realistic_v11_L1v1-v2_NANOAODSIM_skim2mu_1muPt50_1Mll100/merged/merged.root");
-  chaux_ZToMuMu_3500_4500->Add(baseDir+"/ZToMuMu_NNPDF31_TuneCP5_13TeV-powheg-pythia8_M_3500_4500_RunIISummer19UL18NanoAOD-106X_upgrade2018_realistic_v11_L1v1-v2_NANOAODSIM_skim2mu_1muPt50_1Mll100/merged/merged.root");
+  ch_ZToMuMu_3500_4500->Add(baseDir+"/ZToMuMu_NNPDF31_TuneCP5_13TeV-powheg-pythia8_M_3500_4500_RunIISummer19UL18NanoAOD-106X_upgrade2018_realistic_v11_L1v1-v2_NANOAODSIM_skim2mu_1muPt50_1Mll100_allBranches/merged/merged.root");
+  chaux_ZToMuMu_3500_4500->Add(baseDir+"/ZToMuMu_NNPDF31_TuneCP5_13TeV-powheg-pythia8_M_3500_4500_RunIISummer19UL18NanoAOD-106X_upgrade2018_realistic_v11_L1v1-v2_NANOAODSIM_skim2mu_1muPt50_1Mll100_allBranches/merged/merged.root");
   ScanChain(ch_ZToMuMu_3500_4500,getSumOfGenEventSumw(chaux_ZToMuMu_3500_4500,true),"2018","ZToMuMu_3500_4500");
 
-  ch_ZToMuMu_4500_6000->Add(baseDir+"/ZToMuMu_NNPDF31_TuneCP5_13TeV-powheg-pythia8_M_4500_6000_RunIISummer19UL18NanoAOD-106X_upgrade2018_realistic_v11_L1v1-v2_NANOAODSIM_skim2mu_1muPt50_1Mll100/merged/merged.root");
-  chaux_ZToMuMu_4500_6000->Add(baseDir+"/ZToMuMu_NNPDF31_TuneCP5_13TeV-powheg-pythia8_M_4500_6000_RunIISummer19UL18NanoAOD-106X_upgrade2018_realistic_v11_L1v1-v2_NANOAODSIM_skim2mu_1muPt50_1Mll100/merged/merged.root");
+  ch_ZToMuMu_4500_6000->Add(baseDir+"/ZToMuMu_NNPDF31_TuneCP5_13TeV-powheg-pythia8_M_4500_6000_RunIISummer19UL18NanoAOD-106X_upgrade2018_realistic_v11_L1v1-v2_NANOAODSIM_skim2mu_1muPt50_1Mll100_allBranches/merged/merged.root");
+  chaux_ZToMuMu_4500_6000->Add(baseDir+"/ZToMuMu_NNPDF31_TuneCP5_13TeV-powheg-pythia8_M_4500_6000_RunIISummer19UL18NanoAOD-106X_upgrade2018_realistic_v11_L1v1-v2_NANOAODSIM_skim2mu_1muPt50_1Mll100_allBranches/merged/merged.root");
   ScanChain(ch_ZToMuMu_4500_6000,getSumOfGenEventSumw(chaux_ZToMuMu_4500_6000,true),"2018","ZToMuMu_4500_6000");
 
-  ch_ZToMuMu_6000_Inf->Add(baseDir+"/ZToMuMu_NNPDF31_TuneCP5_13TeV-powheg-pythia8_M_6000_Inf_RunIISummer19UL18NanoAOD-106X_upgrade2018_realistic_v11_L1v1-v2_NANOAODSIM_skim2mu_1muPt50_1Mll100/merged/merged.root");
-  chaux_ZToMuMu_6000_Inf->Add(baseDir+"/ZToMuMu_NNPDF31_TuneCP5_13TeV-powheg-pythia8_M_6000_Inf_RunIISummer19UL18NanoAOD-106X_upgrade2018_realistic_v11_L1v1-v2_NANOAODSIM_skim2mu_1muPt50_1Mll100/merged/merged.root");
+  ch_ZToMuMu_6000_Inf->Add(baseDir+"/ZToMuMu_NNPDF31_TuneCP5_13TeV-powheg-pythia8_M_6000_Inf_RunIISummer19UL18NanoAOD-106X_upgrade2018_realistic_v11_L1v1-v2_NANOAODSIM_skim2mu_1muPt50_1Mll100_allBranches/merged/merged.root");
+  chaux_ZToMuMu_6000_Inf->Add(baseDir+"/ZToMuMu_NNPDF31_TuneCP5_13TeV-powheg-pythia8_M_6000_Inf_RunIISummer19UL18NanoAOD-106X_upgrade2018_realistic_v11_L1v1-v2_NANOAODSIM_skim2mu_1muPt50_1Mll100_allBranches/merged/merged.root");
   ScanChain(ch_ZToMuMu_6000_Inf,getSumOfGenEventSumw(chaux_ZToMuMu_6000_Inf,true),"2018","ZToMuMu_6000_Inf");
      
-  ch2->Add(baseDir+"/WW_TuneCP5_13TeV-pythia8_RunIISummer20UL18NanoAODv9-106X_upgrade2018_realistic_v16_L1v1-v1_NANOAODSIM_skim2mu_1muPt50_1Mll100/merged/merged.root");
-  ch2aux->Add(baseDir+"/WW_TuneCP5_13TeV-pythia8_RunIISummer20UL18NanoAODv9-106X_upgrade2018_realistic_v16_L1v1-v1_NANOAODSIM_skim2mu_1muPt50_1Mll100/merged/merged.root");
+  ch2->Add(baseDir+"/WW_TuneCP5_13TeV-pythia8_RunIISummer20UL18NanoAODv9-106X_upgrade2018_realistic_v16_L1v1-v1_NANOAODSIM_skim2mu_1muPt50_1Mll100_allBranches/merged/merged.root");
+  ch2aux->Add(baseDir+"/WW_TuneCP5_13TeV-pythia8_RunIISummer20UL18NanoAODv9-106X_upgrade2018_realistic_v16_L1v1-v1_NANOAODSIM_skim2mu_1muPt50_1Mll100_allBranches/merged/merged.root");
   ScanChain(ch2,getSumOfGenEventSumw(ch2aux),"2018","WW");
  
-  ch3->Add(baseDir+"/WZ_TuneCP5_13TeV-pythia8_RunIISummer20UL18NanoAODv9-106X_upgrade2018_realistic_v16_L1v1-v1_NANOAODSIM_skim2mu_1muPt50_1Mll100/merged/merged.root");
-  ch3aux->Add(baseDir+"/WZ_TuneCP5_13TeV-pythia8_RunIISummer20UL18NanoAODv9-106X_upgrade2018_realistic_v16_L1v1-v1_NANOAODSIM_skim2mu_1muPt50_1Mll100/merged/merged.root");
+  ch3->Add(baseDir+"/WZ_TuneCP5_13TeV-pythia8_RunIISummer20UL18NanoAODv9-106X_upgrade2018_realistic_v16_L1v1-v1_NANOAODSIM_skim2mu_1muPt50_1Mll100_allBranches/merged/merged.root");
+  ch3aux->Add(baseDir+"/WZ_TuneCP5_13TeV-pythia8_RunIISummer20UL18NanoAODv9-106X_upgrade2018_realistic_v16_L1v1-v1_NANOAODSIM_skim2mu_1muPt50_1Mll100_allBranches/merged/merged.root");
   ScanChain(ch3,getSumOfGenEventSumw(ch3aux),"2018","WZ");
    
-  ch4->Add(baseDir+"/ZZ_TuneCP5_13TeV-pythia8_RunIISummer20UL18NanoAODv9-106X_upgrade2018_realistic_v16_L1v1-v1_NANOAODSIM_skim2mu_1muPt50_1Mll100/merged/merged.root");
-  ch4aux->Add(baseDir+"/ZZ_TuneCP5_13TeV-pythia8_RunIISummer20UL18NanoAODv9-106X_upgrade2018_realistic_v16_L1v1-v1_NANOAODSIM_skim2mu_1muPt50_1Mll100/merged/merged.root");
+  ch4->Add(baseDir+"/ZZ_TuneCP5_13TeV-pythia8_RunIISummer20UL18NanoAODv9-106X_upgrade2018_realistic_v16_L1v1-v1_NANOAODSIM_skim2mu_1muPt50_1Mll100_allBranches/merged/merged.root");
+  ch4aux->Add(baseDir+"/ZZ_TuneCP5_13TeV-pythia8_RunIISummer20UL18NanoAODv9-106X_upgrade2018_realistic_v16_L1v1-v1_NANOAODSIM_skim2mu_1muPt50_1Mll100_allBranches/merged/merged.root");
   ScanChain(ch4,getSumOfGenEventSumw(ch4aux),"2018","ZZ");
 
-  ch6->Add(baseDir+"/ST_tW_top_5f_NoFullyHadronicDecays_TuneCP5_13TeV-powheg-pythia8_RunIISummer20UL18NanoAODv9-106X_upgrade2018_realistic_v16_L1v1-v1_NANOAODSIM_skim2mu_1muPt50_1Mll100/merged/merged.root");
-  ch6aux->Add(baseDir+"/ST_tW_top_5f_NoFullyHadronicDecays_TuneCP5_13TeV-powheg-pythia8_RunIISummer20UL18NanoAODv9-106X_upgrade2018_realistic_v16_L1v1-v1_NANOAODSIM_skim2mu_1muPt50_1Mll100/merged/merged.root");
+  ch6->Add(baseDir+"/ST_tW_top_5f_NoFullyHadronicDecays_TuneCP5_13TeV-powheg-pythia8_RunIISummer20UL18NanoAODv9-106X_upgrade2018_realistic_v16_L1v1-v1_NANOAODSIM_skim2mu_1muPt50_1Mll100_allBranches/merged/merged.root");
+  ch6aux->Add(baseDir+"/ST_tW_top_5f_NoFullyHadronicDecays_TuneCP5_13TeV-powheg-pythia8_RunIISummer20UL18NanoAODv9-106X_upgrade2018_realistic_v16_L1v1-v1_NANOAODSIM_skim2mu_1muPt50_1Mll100_allBranches/merged/merged.root");
   ScanChain(ch6,getSumOfGenEventSumw(ch6aux),"2018","tW");
 
-  ch7->Add(baseDir+"/ST_tW_antitop_5f_NoFullyHadronicDecays_TuneCP5_13TeV-powheg-pythia8_RunIISummer20UL18NanoAODv9-106X_upgrade2018_realistic_v16_L1v1-v1_NANOAODSIM_skim2mu_1muPt50_1Mll100/merged/merged.root");
-  ch7aux->Add(baseDir+"/ST_tW_antitop_5f_NoFullyHadronicDecays_TuneCP5_13TeV-powheg-pythia8_RunIISummer20UL18NanoAODv9-106X_upgrade2018_realistic_v16_L1v1-v1_NANOAODSIM_skim2mu_1muPt50_1Mll100/merged/merged.root");
+  ch7->Add(baseDir+"/ST_tW_antitop_5f_NoFullyHadronicDecays_TuneCP5_13TeV-powheg-pythia8_RunIISummer20UL18NanoAODv9-106X_upgrade2018_realistic_v16_L1v1-v1_NANOAODSIM_skim2mu_1muPt50_1Mll100_allBranches/merged/merged.root");
+  ch7aux->Add(baseDir+"/ST_tW_antitop_5f_NoFullyHadronicDecays_TuneCP5_13TeV-powheg-pythia8_RunIISummer20UL18NanoAODv9-106X_upgrade2018_realistic_v16_L1v1-v1_NANOAODSIM_skim2mu_1muPt50_1Mll100_allBranches/merged/merged.root");
   ScanChain(ch7,getSumOfGenEventSumw(ch7aux),"2018","tbarW");
     
-  ch8->Add(baseDir+"/TTWJetsToLNu_TuneCP5_13TeV-amcatnloFXFX-madspin-pythia8_RunIISummer20UL18NanoAODv9-106X_upgrade2018_realistic_v16_L1v1-v1_NANOAODSIM_skim2mu_1muPt50_1Mll100/merged/merged.root");
-  ch8aux->Add(baseDir+"/TTWJetsToLNu_TuneCP5_13TeV-amcatnloFXFX-madspin-pythia8_RunIISummer20UL18NanoAODv9-106X_upgrade2018_realistic_v16_L1v1-v1_NANOAODSIM_skim2mu_1muPt50_1Mll100/merged/merged.root");
+  ch8->Add(baseDir+"/TTWJetsToLNu_TuneCP5_13TeV-amcatnloFXFX-madspin-pythia8_RunIISummer20UL18NanoAODv9-106X_upgrade2018_realistic_v16_L1v1-v1_NANOAODSIM_skim2mu_1muPt50_1Mll100_allBranches/merged/merged.root");
+  ch8aux->Add(baseDir+"/TTWJetsToLNu_TuneCP5_13TeV-amcatnloFXFX-madspin-pythia8_RunIISummer20UL18NanoAODv9-106X_upgrade2018_realistic_v16_L1v1-v1_NANOAODSIM_skim2mu_1muPt50_1Mll100_allBranches/merged/merged.root");
   ScanChain(ch8,getSumOfGenEventSumw(ch8aux),"2018","TTW");
 
-  ch9->Add(baseDir+"/TTZToLLNuNu_M-10_TuneCP5_13TeV-amcatnlo-pythia8_RunIISummer20UL18NanoAODv9-106X_upgrade2018_realistic_v16_L1v1-v1_NANOAODSIM_skim2mu_1muPt50_1Mll100/merged/merged.root");
-  ch9aux->Add(baseDir+"/TTZToLLNuNu_M-10_TuneCP5_13TeV-amcatnlo-pythia8_RunIISummer20UL18NanoAODv9-106X_upgrade2018_realistic_v16_L1v1-v1_NANOAODSIM_skim2mu_1muPt50_1Mll100/merged/merged.root");
+  ch9->Add(baseDir+"/TTZToLLNuNu_M-10_TuneCP5_13TeV-amcatnlo-pythia8_RunIISummer20UL18NanoAODv9-106X_upgrade2018_realistic_v16_L1v1-v1_NANOAODSIM_skim2mu_1muPt50_1Mll100_allBranches/merged/merged.root");
+  ch9aux->Add(baseDir+"/TTZToLLNuNu_M-10_TuneCP5_13TeV-amcatnlo-pythia8_RunIISummer20UL18NanoAODv9-106X_upgrade2018_realistic_v16_L1v1-v1_NANOAODSIM_skim2mu_1muPt50_1Mll100_allBranches/merged/merged.root");
   ScanChain(ch9,getSumOfGenEventSumw(ch9aux),"2018","TTZ");
     
-  ch10->Add(baseDir+"/ttHJetToNonbb_M125_TuneCP5_13TeV_amcatnloFXFX_madspin_pythia8_RunIISummer20UL18NanoAODv9-106X_upgrade2018_realistic_v16_L1v1-v1_NANOAODSIM_skim2mu_1muPt50_1Mll100/merged/merged.root");
-  ch10aux->Add(baseDir+"/ttHJetToNonbb_M125_TuneCP5_13TeV_amcatnloFXFX_madspin_pythia8_RunIISummer20UL18NanoAODv9-106X_upgrade2018_realistic_v16_L1v1-v1_NANOAODSIM_skim2mu_1muPt50_1Mll100/merged/merged.root");
+  ch10->Add(baseDir+"/ttHJetToNonbb_M125_TuneCP5_13TeV_amcatnloFXFX_madspin_pythia8_RunIISummer20UL18NanoAODv9-106X_upgrade2018_realistic_v16_L1v1-v1_NANOAODSIM_skim2mu_1muPt50_1Mll100_allBranches/merged/merged.root");
+  ch10aux->Add(baseDir+"/ttHJetToNonbb_M125_TuneCP5_13TeV_amcatnloFXFX_madspin_pythia8_RunIISummer20UL18NanoAODv9-106X_upgrade2018_realistic_v16_L1v1-v1_NANOAODSIM_skim2mu_1muPt50_1Mll100_allBranches/merged/merged.root");
   ScanChain(ch10,getSumOfGenEventSumw(ch10aux),"2018","TTHToNonbb");
     
   //ch11->Add("");
@@ -148,32 +148,32 @@
   //ScanChain(ch11,getSumOfGenEventSumw(ch11aux),"2018","TTHTobb");
  
   // Signal Y3, 2018
-  ch_Y3_M100->Add(baseSignalDir+"/ZPrimeToMuMuSB_M100_bestfit_TuneCP5_13TeV_Allanach_Y3_5f_madgraph_pythia8_NoPSWgts_RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v2_private_NANOAODSIM_skim2mu_1muPt50_1Mll100_PrivSignal/merged/merged.root");
-  chaux_Y3_M100->Add(baseSignalDir+"/ZPrimeToMuMuSB_M100_bestfit_TuneCP5_13TeV_Allanach_Y3_5f_madgraph_pythia8_NoPSWgts_RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v2_private_NANOAODSIM_skim2mu_1muPt50_1Mll100_PrivSignal/merged/merged.root");
+  ch_Y3_M100->Add(baseSignalDir+"/ZPrimeToMuMuSB_M100_bestfit_TuneCP5_13TeV_Allanach_Y3_5f_madgraph_pythia8_NoPSWgts_RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v2_private_NANOAODSIM_skim2mu_1muPt50_1Mll100_allBranches/merged/merged.root");
+  chaux_Y3_M100->Add(baseSignalDir+"/ZPrimeToMuMuSB_M100_bestfit_TuneCP5_13TeV_Allanach_Y3_5f_madgraph_pythia8_NoPSWgts_RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v2_private_NANOAODSIM_skim2mu_1muPt50_1Mll100_allBranches/merged/merged.root");
   ScanChain(ch_Y3_M100,getSumOfGenEventSumw(chaux_Y3_M100),"2018","Y3_M100");
 
-  ch5->Add(baseSignalDir+"/ZPrimeToMuMuSB_M200_bestfit_TuneCP5_13TeV_Allanach_Y3_5f_madgraph_pythia8_NoPSWgts_RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v2_private_NANOAODSIM_skim2mu_1muPt50_1Mll100_PrivSignal/merged/merged.root");
-  ch5aux->Add(baseSignalDir+"/ZPrimeToMuMuSB_M200_bestfit_TuneCP5_13TeV_Allanach_Y3_5f_madgraph_pythia8_NoPSWgts_RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v2_private_NANOAODSIM_skim2mu_1muPt50_1Mll100_PrivSignal/merged/merged.root");
+  ch5->Add(baseSignalDir+"/ZPrimeToMuMuSB_M200_bestfit_TuneCP5_13TeV_Allanach_Y3_5f_madgraph_pythia8_NoPSWgts_RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v2_private_NANOAODSIM_skim2mu_1muPt50_1Mll100_allBranches/merged/merged.root");
+  ch5aux->Add(baseSignalDir+"/ZPrimeToMuMuSB_M200_bestfit_TuneCP5_13TeV_Allanach_Y3_5f_madgraph_pythia8_NoPSWgts_RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v2_private_NANOAODSIM_skim2mu_1muPt50_1Mll100_allBranches/merged/merged.root");
   ScanChain(ch5,getSumOfGenEventSumw(ch5aux),"2018","Y3_M200");
 
-  ch_Y3_M400->Add(baseSignalDir+"/ZPrimeToMuMuSB_M400_bestfit_TuneCP5_13TeV_Allanach_Y3_5f_madgraph_pythia8_NoPSWgts_RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v2_private_NANOAODSIM_skim2mu_1muPt50_1Mll100_PrivSignal/merged/merged.root");
-  chaux_Y3_M400->Add(baseSignalDir+"/ZPrimeToMuMuSB_M400_bestfit_TuneCP5_13TeV_Allanach_Y3_5f_madgraph_pythia8_NoPSWgts_RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v2_private_NANOAODSIM_skim2mu_1muPt50_1Mll100_PrivSignal/merged/merged.root");
+  ch_Y3_M400->Add(baseSignalDir+"/ZPrimeToMuMuSB_M400_bestfit_TuneCP5_13TeV_Allanach_Y3_5f_madgraph_pythia8_NoPSWgts_RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v2_private_NANOAODSIM_skim2mu_1muPt50_1Mll100_allBranches/merged/merged.root");
+  chaux_Y3_M400->Add(baseSignalDir+"/ZPrimeToMuMuSB_M400_bestfit_TuneCP5_13TeV_Allanach_Y3_5f_madgraph_pythia8_NoPSWgts_RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v2_private_NANOAODSIM_skim2mu_1muPt50_1Mll100_allBranches/merged/merged.root");
   ScanChain(ch_Y3_M400,getSumOfGenEventSumw(chaux_Y3_M400),"2018","Y3_M400");
 
-  ch_Y3_M700->Add(baseSignalDir+"/ZPrimeToMuMuSB_M700_bestfit_TuneCP5_13TeV_Allanach_Y3_5f_madgraph_pythia8_NoPSWgts_RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v2_private_NANOAODSIM_skim2mu_1muPt50_1Mll100_PrivSignal/merged/merged.root");
-  chaux_Y3_M700->Add(baseSignalDir+"/ZPrimeToMuMuSB_M700_bestfit_TuneCP5_13TeV_Allanach_Y3_5f_madgraph_pythia8_NoPSWgts_RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v2_private_NANOAODSIM_skim2mu_1muPt50_1Mll100_PrivSignal/merged/merged.root");
+  ch_Y3_M700->Add(baseSignalDir+"/ZPrimeToMuMuSB_M700_bestfit_TuneCP5_13TeV_Allanach_Y3_5f_madgraph_pythia8_NoPSWgts_RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v2_private_NANOAODSIM_skim2mu_1muPt50_1Mll100_allBranches/merged/merged.root");
+  chaux_Y3_M700->Add(baseSignalDir+"/ZPrimeToMuMuSB_M700_bestfit_TuneCP5_13TeV_Allanach_Y3_5f_madgraph_pythia8_NoPSWgts_RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v2_private_NANOAODSIM_skim2mu_1muPt50_1Mll100_allBranches/merged/merged.root");
   ScanChain(ch_Y3_M700,getSumOfGenEventSumw(chaux_Y3_M700),"2018","Y3_M700");
 
-  ch_Y3_M1000->Add(baseSignalDir+"/ZPrimeToMuMuSB_M1000_bestfit_TuneCP5_13TeV_Allanach_Y3_5f_madgraph_pythia8_NoPSWgts_RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v2_private_NANOAODSIM_skim2mu_1muPt50_1Mll100_PrivSignal/merged/merged.root");
-  chaux_Y3_M1000->Add(baseSignalDir+"/ZPrimeToMuMuSB_M1000_bestfit_TuneCP5_13TeV_Allanach_Y3_5f_madgraph_pythia8_NoPSWgts_RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v2_private_NANOAODSIM_skim2mu_1muPt50_1Mll100_PrivSignal/merged/merged.root");
+  ch_Y3_M1000->Add(baseSignalDir+"/ZPrimeToMuMuSB_M1000_bestfit_TuneCP5_13TeV_Allanach_Y3_5f_madgraph_pythia8_NoPSWgts_RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v2_private_NANOAODSIM_skim2mu_1muPt50_1Mll100_allBranches/merged/merged.root");
+  chaux_Y3_M1000->Add(baseSignalDir+"/ZPrimeToMuMuSB_M1000_bestfit_TuneCP5_13TeV_Allanach_Y3_5f_madgraph_pythia8_NoPSWgts_RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v2_private_NANOAODSIM_skim2mu_1muPt50_1Mll100_allBranches/merged/merged.root");
   ScanChain(ch_Y3_M1000,getSumOfGenEventSumw(chaux_Y3_M1000),"2018","Y3_M1000");
 
-  ch_Y3_M1500->Add(baseSignalDir+"/ZPrimeToMuMuSB_M1500_bestfit_TuneCP5_13TeV_Allanach_Y3_5f_madgraph_pythia8_NoPSWgts_RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v2_private_NANOAODSIM_skim2mu_1muPt50_1Mll100_PrivSignal/merged/merged.root");
-  chaux_Y3_M1500->Add(baseSignalDir+"/ZPrimeToMuMuSB_M1500_bestfit_TuneCP5_13TeV_Allanach_Y3_5f_madgraph_pythia8_NoPSWgts_RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v2_private_NANOAODSIM_skim2mu_1muPt50_1Mll100_PrivSignal/merged/merged.root");
+  ch_Y3_M1500->Add(baseSignalDir+"/ZPrimeToMuMuSB_M1500_bestfit_TuneCP5_13TeV_Allanach_Y3_5f_madgraph_pythia8_NoPSWgts_RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v2_private_NANOAODSIM_skim2mu_1muPt50_1Mll100_allBranches/merged/merged.root");
+  chaux_Y3_M1500->Add(baseSignalDir+"/ZPrimeToMuMuSB_M1500_bestfit_TuneCP5_13TeV_Allanach_Y3_5f_madgraph_pythia8_NoPSWgts_RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v2_private_NANOAODSIM_skim2mu_1muPt50_1Mll100_allBranches/merged/merged.root");
   ScanChain(ch_Y3_M1500,getSumOfGenEventSumw(chaux_Y3_M1500),"2018","Y3_M1500");
 
-  ch_Y3_M2000->Add(baseSignalDir+"/ZPrimeToMuMuSB_M2000_bestfit_TuneCP5_13TeV_Allanach_Y3_5f_madgraph_pythia8_NoPSWgts_RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v2_private_NANOAODSIM_skim2mu_1muPt50_1Mll100_PrivSignal/merged/merged.root");
-  chaux_Y3_M2000->Add(baseSignalDir+"/ZPrimeToMuMuSB_M2000_bestfit_TuneCP5_13TeV_Allanach_Y3_5f_madgraph_pythia8_NoPSWgts_RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v2_private_NANOAODSIM_skim2mu_1muPt50_1Mll100_PrivSignal/merged/merged.root");
+  ch_Y3_M2000->Add(baseSignalDir+"/ZPrimeToMuMuSB_M2000_bestfit_TuneCP5_13TeV_Allanach_Y3_5f_madgraph_pythia8_NoPSWgts_RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v2_private_NANOAODSIM_skim2mu_1muPt50_1Mll100_allBranches/merged/merged.root");
+  chaux_Y3_M2000->Add(baseSignalDir+"/ZPrimeToMuMuSB_M2000_bestfit_TuneCP5_13TeV_Allanach_Y3_5f_madgraph_pythia8_NoPSWgts_RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v2_private_NANOAODSIM_skim2mu_1muPt50_1Mll100_allBranches/merged/merged.root");
   ScanChain(ch_Y3_M2000,getSumOfGenEventSumw(chaux_Y3_M2000),"2018","Y3_M2000");
 
 }

--- a/cpp/doAll_Zp.C
+++ b/cpp/doAll_Zp.C
@@ -1,194 +1,194 @@
 {
-    gROOT->ProcessLine(".L ../NanoCORE/NANO_CORE.so");  // NanoCORE library
-    gROOT->ProcessLine(".L ScanChain_Zp.C+");  // Macro that performs the selection
-    TChain *ch = new TChain("Events");
-    TChain *chaux = new TChain("Runs");
-    TChain *ch1 = new TChain("Events");
-    TChain *ch1aux = new TChain("Runs");
-    TChain *ch2 = new TChain("Events");
-    TChain *ch2aux = new TChain("Runs");
-    TChain *ch3 = new TChain("Events");
-    TChain *ch3aux = new TChain("Runs");
-    TChain *ch4 = new TChain("Events");
-    TChain *ch4aux = new TChain("Runs");
-    TChain *ch5 = new TChain("Events");
-    TChain *ch5aux = new TChain("Runs");
-    TChain *ch6 = new TChain("Events");
-    TChain *ch6aux = new TChain("Runs");
-    TChain *ch7 = new TChain("Events");
-    TChain *ch7aux = new TChain("Runs");
-    TChain *ch8 = new TChain("Events");
-    TChain *ch8aux = new TChain("Runs");
-    TChain *ch9 = new TChain("Events");
-    TChain *ch9aux = new TChain("Runs");
-    TChain *ch10 = new TChain("Events");
-    TChain *ch10aux = new TChain("Runs");
-    //TChain *ch11 = new TChain("Events");
-    //TChain *ch11aux = new TChain("Runs");
-    TChain *ch_Y3_M100 = new TChain("Events");
-    TChain *chaux_Y3_M100 = new TChain("Runs");
-    TChain *ch_Y3_M200 = new TChain("Events");
-    TChain *chaux_Y3_M200 = new TChain("Runs");
-    TChain *ch_Y3_M400 = new TChain("Events");
-    TChain *chaux_Y3_M400 = new TChain("Runs");
-    TChain *ch_Y3_M700 = new TChain("Events");
-    TChain *chaux_Y3_M700 = new TChain("Runs");
-    TChain *ch_Y3_M1000 = new TChain("Events");
-    TChain *chaux_Y3_M1000 = new TChain("Runs");
-    TChain *ch_Y3_M1500 = new TChain("Events");
-    TChain *chaux_Y3_M1500 = new TChain("Runs");
-    TChain *ch_Y3_M2000 = new TChain("Events");
-    TChain *chaux_Y3_M2000 = new TChain("Runs");
-    TChain *ch_ZToMuMu_50_120 = new TChain("Events");
-    TChain *chaux_ZToMuMu_50_120 = new TChain("Runs");
-    TChain *ch_ZToMuMu_120_200 = new TChain("Events");
-    TChain *chaux_ZToMuMu_120_200 = new TChain("Runs");
-    TChain *ch_ZToMuMu_200_400 = new TChain("Events");
-    TChain *chaux_ZToMuMu_200_400 = new TChain("Runs");
-    TChain *ch_ZToMuMu_400_800 = new TChain("Events");
-    TChain *chaux_ZToMuMu_400_800 = new TChain("Runs");
-    TChain *ch_ZToMuMu_800_1400 = new TChain("Events");
-    TChain *chaux_ZToMuMu_800_1400 = new TChain("Runs");
-    TChain *ch_ZToMuMu_1400_2300 = new TChain("Events");
-    TChain *chaux_ZToMuMu_1400_2300 = new TChain("Runs");
-    TChain *ch_ZToMuMu_2300_3500 = new TChain("Events");
-    TChain *chaux_ZToMuMu_2300_3500 = new TChain("Runs");
-    TChain *ch_ZToMuMu_3500_4500 = new TChain("Events");
-    TChain *chaux_ZToMuMu_3500_4500 = new TChain("Runs");
-    TChain *ch_ZToMuMu_4500_6000 = new TChain("Events");
-    TChain *chaux_ZToMuMu_4500_6000 = new TChain("Runs");
-    TChain *ch_ZToMuMu_6000_Inf = new TChain("Events");
-    TChain *chaux_ZToMuMu_6000_Inf = new TChain("Runs");
+  gROOT->ProcessLine(".L ../NanoCORE/NANO_CORE.so");  // NanoCORE library
+  gROOT->ProcessLine(".L ScanChain_Zp.C+");  // Macro that performs the selection
+  TChain *ch = new TChain("Events");
+  TChain *chaux = new TChain("Runs");
+  TChain *ch1 = new TChain("Events");
+  TChain *ch1aux = new TChain("Runs");
+  TChain *ch2 = new TChain("Events");
+  TChain *ch2aux = new TChain("Runs");
+  TChain *ch3 = new TChain("Events");
+  TChain *ch3aux = new TChain("Runs");
+  TChain *ch4 = new TChain("Events");
+  TChain *ch4aux = new TChain("Runs");
+  TChain *ch5 = new TChain("Events");
+  TChain *ch5aux = new TChain("Runs");
+  TChain *ch6 = new TChain("Events");
+  TChain *ch6aux = new TChain("Runs");
+  TChain *ch7 = new TChain("Events");
+  TChain *ch7aux = new TChain("Runs");
+  TChain *ch8 = new TChain("Events");
+  TChain *ch8aux = new TChain("Runs");
+  TChain *ch9 = new TChain("Events");
+  TChain *ch9aux = new TChain("Runs");
+  TChain *ch10 = new TChain("Events");
+  TChain *ch10aux = new TChain("Runs");
+  //TChain *ch11 = new TChain("Events");
+  //TChain *ch11aux = new TChain("Runs");
+  TChain *ch_Y3_M100 = new TChain("Events");
+  TChain *chaux_Y3_M100 = new TChain("Runs");
+  TChain *ch_Y3_M200 = new TChain("Events");
+  TChain *chaux_Y3_M200 = new TChain("Runs");
+  TChain *ch_Y3_M400 = new TChain("Events");
+  TChain *chaux_Y3_M400 = new TChain("Runs");
+  TChain *ch_Y3_M700 = new TChain("Events");
+  TChain *chaux_Y3_M700 = new TChain("Runs");
+  TChain *ch_Y3_M1000 = new TChain("Events");
+  TChain *chaux_Y3_M1000 = new TChain("Runs");
+  TChain *ch_Y3_M1500 = new TChain("Events");
+  TChain *chaux_Y3_M1500 = new TChain("Runs");
+  TChain *ch_Y3_M2000 = new TChain("Events");
+  TChain *chaux_Y3_M2000 = new TChain("Runs");
+  TChain *ch_ZToMuMu_50_120 = new TChain("Events");
+  TChain *chaux_ZToMuMu_50_120 = new TChain("Runs");
+  TChain *ch_ZToMuMu_120_200 = new TChain("Events");
+  TChain *chaux_ZToMuMu_120_200 = new TChain("Runs");
+  TChain *ch_ZToMuMu_200_400 = new TChain("Events");
+  TChain *chaux_ZToMuMu_200_400 = new TChain("Runs");
+  TChain *ch_ZToMuMu_400_800 = new TChain("Events");
+  TChain *chaux_ZToMuMu_400_800 = new TChain("Runs");
+  TChain *ch_ZToMuMu_800_1400 = new TChain("Events");
+  TChain *chaux_ZToMuMu_800_1400 = new TChain("Runs");
+  TChain *ch_ZToMuMu_1400_2300 = new TChain("Events");
+  TChain *chaux_ZToMuMu_1400_2300 = new TChain("Runs");
+  TChain *ch_ZToMuMu_2300_3500 = new TChain("Events");
+  TChain *chaux_ZToMuMu_2300_3500 = new TChain("Runs");
+  TChain *ch_ZToMuMu_3500_4500 = new TChain("Events");
+  TChain *chaux_ZToMuMu_3500_4500 = new TChain("Runs");
+  TChain *ch_ZToMuMu_4500_6000 = new TChain("Events");
+  TChain *chaux_ZToMuMu_4500_6000 = new TChain("Runs");
+  TChain *ch_ZToMuMu_6000_Inf = new TChain("Events");
+  TChain *chaux_ZToMuMu_6000_Inf = new TChain("Runs");
 
-    TString baseDir = "/ceph/cms/store/user/evourlio/skimOutput/skim2mu_1muPt50_1Mll100";
-    TString baseSignalDir = "/ceph/cms/store/user/evourlio/skimOutput/skim2mu_1muPt50_1Mll100_PrivSignal";
-    // Files to be looped over
-    ch->Add(baseDir+"/TTTo2L2Nu_TuneCP5_13TeV-powheg-pythia8_RunIISummer20UL18NanoAODv9-106X_upgrade2018_realistic_v16_L1v1-v1_NANOAODSIM_skim2mu_1muPt50_1Mll100/merged/merged.root");
-    chaux->Add(baseDir+"/TTTo2L2Nu_TuneCP5_13TeV-powheg-pythia8_RunIISummer20UL18NanoAODv9-106X_upgrade2018_realistic_v16_L1v1-v1_NANOAODSIM_skim2mu_1muPt50_1Mll100/merged/merged.root");
-    ScanChain(ch,getSumOfGenEventSumw(chaux),"2018","ttbar");
+  TString baseDir = "/ceph/cms/store/user/evourlio/skimOutput/skim2mu_1muPt50_1Mll100";
+  TString baseSignalDir = "/ceph/cms/store/user/evourlio/skimOutput/skim2mu_1muPt50_1Mll100_PrivSignal";
+  // Files to be looped over
+  ch->Add(baseDir+"/TTTo2L2Nu_TuneCP5_13TeV-powheg-pythia8_RunIISummer20UL18NanoAODv9-106X_upgrade2018_realistic_v16_L1v1-v1_NANOAODSIM_skim2mu_1muPt50_1Mll100/merged/merged.root");
+  chaux->Add(baseDir+"/TTTo2L2Nu_TuneCP5_13TeV-powheg-pythia8_RunIISummer20UL18NanoAODv9-106X_upgrade2018_realistic_v16_L1v1-v1_NANOAODSIM_skim2mu_1muPt50_1Mll100/merged/merged.root");
+  ScanChain(ch,getSumOfGenEventSumw(chaux),"2018","ttbar");
 
-    //ch1->Add(baseDir+"/DYJetsToLL_M-50_TuneCP5_13TeV-amcatnloFXFX-pythia8_RunIISummer20UL18NanoAODv9-106X_upgrade2018_realistic_v16_L1v1-v2_NANOAODSIM_skim2mu_1muPt50_1Mll100/merged/merged.root");
-    //ch1aux->Add(baseDir+"/DYJetsToLL_M-50_TuneCP5_13TeV-amcatnloFXFX-pythia8_RunIISummer20UL18NanoAODv9-106X_upgrade2018_realistic_v16_L1v1-v2_NANOAODSIM_skim2mu_1muPt50_1Mll100/merged/merged.root");
-    //ScanChain(ch1,getSumOfGenEventSumw(ch1aux),"2018","DY");
+  //ch1->Add(baseDir+"/DYJetsToLL_M-50_TuneCP5_13TeV-amcatnloFXFX-pythia8_RunIISummer20UL18NanoAODv9-106X_upgrade2018_realistic_v16_L1v1-v2_NANOAODSIM_skim2mu_1muPt50_1Mll100/merged/merged.root");
+  //ch1aux->Add(baseDir+"/DYJetsToLL_M-50_TuneCP5_13TeV-amcatnloFXFX-pythia8_RunIISummer20UL18NanoAODv9-106X_upgrade2018_realistic_v16_L1v1-v2_NANOAODSIM_skim2mu_1muPt50_1Mll100/merged/merged.root");
+  //ScanChain(ch1,getSumOfGenEventSumw(ch1aux),"2018","DY");
 
-    ch_ZToMuMu_50_120->Add(baseDir+"/ZToMuMu_NNPDF31_TuneCP5_13TeV-powheg-pythia8_M_50_120_RunIISummer19UL18NanoAOD-106X_upgrade2018_realistic_v11_L1v1-v1_NANOAODSIM_skim2mu_1muPt50_1Mll100/merged/merged.root");
-    chaux_ZToMuMu_50_120->Add(baseDir+"/ZToMuMu_NNPDF31_TuneCP5_13TeV-powheg-pythia8_M_50_120_RunIISummer19UL18NanoAOD-106X_upgrade2018_realistic_v11_L1v1-v1_NANOAODSIM_skim2mu_1muPt50_1Mll100/merged/merged.root");
-    ScanChain(ch_ZToMuMu_50_120,getSumOfGenEventSumw(chaux_ZToMuMu_50_120,true),"2018","ZToMuMu_50_120");
+  ch_ZToMuMu_50_120->Add(baseDir+"/ZToMuMu_NNPDF31_TuneCP5_13TeV-powheg-pythia8_M_50_120_RunIISummer19UL18NanoAOD-106X_upgrade2018_realistic_v11_L1v1-v1_NANOAODSIM_skim2mu_1muPt50_1Mll100/merged/merged.root");
+  chaux_ZToMuMu_50_120->Add(baseDir+"/ZToMuMu_NNPDF31_TuneCP5_13TeV-powheg-pythia8_M_50_120_RunIISummer19UL18NanoAOD-106X_upgrade2018_realistic_v11_L1v1-v1_NANOAODSIM_skim2mu_1muPt50_1Mll100/merged/merged.root");
+  ScanChain(ch_ZToMuMu_50_120,getSumOfGenEventSumw(chaux_ZToMuMu_50_120,true),"2018","ZToMuMu_50_120");
 
-    ch_ZToMuMu_120_200->Add(baseDir+"/ZToMuMu_NNPDF31_TuneCP5_13TeV-powheg-pythia8_M_120_200_RunIISummer19UL18NanoAOD-106X_upgrade2018_realistic_v11_L1v1-v2_NANOAODSIM_skim2mu_1muPt50_1Mll100/merged/merged.root");
-    chaux_ZToMuMu_120_200->Add(baseDir+"/ZToMuMu_NNPDF31_TuneCP5_13TeV-powheg-pythia8_M_120_200_RunIISummer19UL18NanoAOD-106X_upgrade2018_realistic_v11_L1v1-v2_NANOAODSIM_skim2mu_1muPt50_1Mll100/merged/merged.root");
-    ScanChain(ch_ZToMuMu_120_200,getSumOfGenEventSumw(chaux_ZToMuMu_120_200,true),"2018","ZToMuMu_120_200");
+  ch_ZToMuMu_120_200->Add(baseDir+"/ZToMuMu_NNPDF31_TuneCP5_13TeV-powheg-pythia8_M_120_200_RunIISummer19UL18NanoAOD-106X_upgrade2018_realistic_v11_L1v1-v2_NANOAODSIM_skim2mu_1muPt50_1Mll100/merged/merged.root");
+  chaux_ZToMuMu_120_200->Add(baseDir+"/ZToMuMu_NNPDF31_TuneCP5_13TeV-powheg-pythia8_M_120_200_RunIISummer19UL18NanoAOD-106X_upgrade2018_realistic_v11_L1v1-v2_NANOAODSIM_skim2mu_1muPt50_1Mll100/merged/merged.root");
+  ScanChain(ch_ZToMuMu_120_200,getSumOfGenEventSumw(chaux_ZToMuMu_120_200,true),"2018","ZToMuMu_120_200");
 
-    ch_ZToMuMu_200_400->Add(baseDir+"/ZToMuMu_NNPDF31_TuneCP5_13TeV-powheg-pythia8_M_200_400_RunIISummer19UL18NanoAOD-106X_upgrade2018_realistic_v11_L1v1-v1_NANOAODSIM_skim2mu_1muPt50_1Mll100/merged/merged.root");
-    chaux_ZToMuMu_200_400->Add(baseDir+"/ZToMuMu_NNPDF31_TuneCP5_13TeV-powheg-pythia8_M_200_400_RunIISummer19UL18NanoAOD-106X_upgrade2018_realistic_v11_L1v1-v1_NANOAODSIM_skim2mu_1muPt50_1Mll100/merged/merged.root");
-    ScanChain(ch_ZToMuMu_200_400,getSumOfGenEventSumw(chaux_ZToMuMu_200_400,true),"2018","ZToMuMu_200_400");
+  ch_ZToMuMu_200_400->Add(baseDir+"/ZToMuMu_NNPDF31_TuneCP5_13TeV-powheg-pythia8_M_200_400_RunIISummer19UL18NanoAOD-106X_upgrade2018_realistic_v11_L1v1-v1_NANOAODSIM_skim2mu_1muPt50_1Mll100/merged/merged.root");
+  chaux_ZToMuMu_200_400->Add(baseDir+"/ZToMuMu_NNPDF31_TuneCP5_13TeV-powheg-pythia8_M_200_400_RunIISummer19UL18NanoAOD-106X_upgrade2018_realistic_v11_L1v1-v1_NANOAODSIM_skim2mu_1muPt50_1Mll100/merged/merged.root");
+  ScanChain(ch_ZToMuMu_200_400,getSumOfGenEventSumw(chaux_ZToMuMu_200_400,true),"2018","ZToMuMu_200_400");
 
-    ch_ZToMuMu_400_800->Add(baseDir+"/ZToMuMu_NNPDF31_TuneCP5_13TeV-powheg-pythia8_M_400_800_RunIISummer19UL18NanoAOD-106X_upgrade2018_realistic_v11_L1v1-v2_NANOAODSIM_skim2mu_1muPt50_1Mll100/merged/merged.root");
-    chaux_ZToMuMu_400_800->Add(baseDir+"/ZToMuMu_NNPDF31_TuneCP5_13TeV-powheg-pythia8_M_400_800_RunIISummer19UL18NanoAOD-106X_upgrade2018_realistic_v11_L1v1-v2_NANOAODSIM_skim2mu_1muPt50_1Mll100/merged/merged.root");
-    ScanChain(ch_ZToMuMu_400_800,getSumOfGenEventSumw(chaux_ZToMuMu_400_800,true),"2018","ZToMuMu_400_800");
+  ch_ZToMuMu_400_800->Add(baseDir+"/ZToMuMu_NNPDF31_TuneCP5_13TeV-powheg-pythia8_M_400_800_RunIISummer19UL18NanoAOD-106X_upgrade2018_realistic_v11_L1v1-v2_NANOAODSIM_skim2mu_1muPt50_1Mll100/merged/merged.root");
+  chaux_ZToMuMu_400_800->Add(baseDir+"/ZToMuMu_NNPDF31_TuneCP5_13TeV-powheg-pythia8_M_400_800_RunIISummer19UL18NanoAOD-106X_upgrade2018_realistic_v11_L1v1-v2_NANOAODSIM_skim2mu_1muPt50_1Mll100/merged/merged.root");
+  ScanChain(ch_ZToMuMu_400_800,getSumOfGenEventSumw(chaux_ZToMuMu_400_800,true),"2018","ZToMuMu_400_800");
 
-    ch_ZToMuMu_800_1400->Add(baseDir+"/ZToMuMu_NNPDF31_TuneCP5_13TeV-powheg-pythia8_M_800_1400_RunIISummer19UL18NanoAOD-106X_upgrade2018_realistic_v11_L1v1-v2_NANOAODSIM_skim2mu_1muPt50_1Mll100/merged/merged.root");
-    chaux_ZToMuMu_800_1400->Add(baseDir+"/ZToMuMu_NNPDF31_TuneCP5_13TeV-powheg-pythia8_M_800_1400_RunIISummer19UL18NanoAOD-106X_upgrade2018_realistic_v11_L1v1-v2_NANOAODSIM_skim2mu_1muPt50_1Mll100/merged/merged.root");
-    ScanChain(ch_ZToMuMu_800_1400,getSumOfGenEventSumw(chaux_ZToMuMu_800_1400,true),"2018","ZToMuMu_800_1400");
+  ch_ZToMuMu_800_1400->Add(baseDir+"/ZToMuMu_NNPDF31_TuneCP5_13TeV-powheg-pythia8_M_800_1400_RunIISummer19UL18NanoAOD-106X_upgrade2018_realistic_v11_L1v1-v2_NANOAODSIM_skim2mu_1muPt50_1Mll100/merged/merged.root");
+  chaux_ZToMuMu_800_1400->Add(baseDir+"/ZToMuMu_NNPDF31_TuneCP5_13TeV-powheg-pythia8_M_800_1400_RunIISummer19UL18NanoAOD-106X_upgrade2018_realistic_v11_L1v1-v2_NANOAODSIM_skim2mu_1muPt50_1Mll100/merged/merged.root");
+  ScanChain(ch_ZToMuMu_800_1400,getSumOfGenEventSumw(chaux_ZToMuMu_800_1400,true),"2018","ZToMuMu_800_1400");
 
-    ch_ZToMuMu_1400_2300->Add(baseDir+"/ZToMuMu_NNPDF31_TuneCP5_13TeV-powheg-pythia8_M_1400_2300_RunIISummer19UL18NanoAOD-106X_upgrade2018_realistic_v11_L1v1-v2_NANOAODSIM_skim2mu_1muPt50_1Mll100/merged/merged.root");
-    chaux_ZToMuMu_1400_2300->Add(baseDir+"/ZToMuMu_NNPDF31_TuneCP5_13TeV-powheg-pythia8_M_1400_2300_RunIISummer19UL18NanoAOD-106X_upgrade2018_realistic_v11_L1v1-v2_NANOAODSIM_skim2mu_1muPt50_1Mll100/merged/merged.root");
-    ScanChain(ch_ZToMuMu_1400_2300,getSumOfGenEventSumw(chaux_ZToMuMu_1400_2300,true),"2018","ZToMuMu_1400_2300");
+  ch_ZToMuMu_1400_2300->Add(baseDir+"/ZToMuMu_NNPDF31_TuneCP5_13TeV-powheg-pythia8_M_1400_2300_RunIISummer19UL18NanoAOD-106X_upgrade2018_realistic_v11_L1v1-v2_NANOAODSIM_skim2mu_1muPt50_1Mll100/merged/merged.root");
+  chaux_ZToMuMu_1400_2300->Add(baseDir+"/ZToMuMu_NNPDF31_TuneCP5_13TeV-powheg-pythia8_M_1400_2300_RunIISummer19UL18NanoAOD-106X_upgrade2018_realistic_v11_L1v1-v2_NANOAODSIM_skim2mu_1muPt50_1Mll100/merged/merged.root");
+  ScanChain(ch_ZToMuMu_1400_2300,getSumOfGenEventSumw(chaux_ZToMuMu_1400_2300,true),"2018","ZToMuMu_1400_2300");
 
-    ch_ZToMuMu_2300_3500->Add(baseDir+"/ZToMuMu_NNPDF31_TuneCP5_13TeV-powheg-pythia8_M_2300_3500_RunIISummer19UL18NanoAOD-106X_upgrade2018_realistic_v11_L1v1-v2_NANOAODSIM_skim2mu_1muPt50_1Mll100/merged/merged.root");
-    chaux_ZToMuMu_2300_3500->Add(baseDir+"/ZToMuMu_NNPDF31_TuneCP5_13TeV-powheg-pythia8_M_2300_3500_RunIISummer19UL18NanoAOD-106X_upgrade2018_realistic_v11_L1v1-v2_NANOAODSIM_skim2mu_1muPt50_1Mll100/merged/merged.root");
-    ScanChain(ch_ZToMuMu_2300_3500,getSumOfGenEventSumw(chaux_ZToMuMu_2300_3500,true),"2018","ZToMuMu_2300_3500");
+  ch_ZToMuMu_2300_3500->Add(baseDir+"/ZToMuMu_NNPDF31_TuneCP5_13TeV-powheg-pythia8_M_2300_3500_RunIISummer19UL18NanoAOD-106X_upgrade2018_realistic_v11_L1v1-v2_NANOAODSIM_skim2mu_1muPt50_1Mll100/merged/merged.root");
+  chaux_ZToMuMu_2300_3500->Add(baseDir+"/ZToMuMu_NNPDF31_TuneCP5_13TeV-powheg-pythia8_M_2300_3500_RunIISummer19UL18NanoAOD-106X_upgrade2018_realistic_v11_L1v1-v2_NANOAODSIM_skim2mu_1muPt50_1Mll100/merged/merged.root");
+  ScanChain(ch_ZToMuMu_2300_3500,getSumOfGenEventSumw(chaux_ZToMuMu_2300_3500,true),"2018","ZToMuMu_2300_3500");
 
-    ch_ZToMuMu_3500_4500->Add(baseDir+"/ZToMuMu_NNPDF31_TuneCP5_13TeV-powheg-pythia8_M_3500_4500_RunIISummer19UL18NanoAOD-106X_upgrade2018_realistic_v11_L1v1-v2_NANOAODSIM_skim2mu_1muPt50_1Mll100/merged/merged.root");
-    chaux_ZToMuMu_3500_4500->Add(baseDir+"/ZToMuMu_NNPDF31_TuneCP5_13TeV-powheg-pythia8_M_3500_4500_RunIISummer19UL18NanoAOD-106X_upgrade2018_realistic_v11_L1v1-v2_NANOAODSIM_skim2mu_1muPt50_1Mll100/merged/merged.root");
-    ScanChain(ch_ZToMuMu_3500_4500,getSumOfGenEventSumw(chaux_ZToMuMu_3500_4500,true),"2018","ZToMuMu_3500_4500");
+  ch_ZToMuMu_3500_4500->Add(baseDir+"/ZToMuMu_NNPDF31_TuneCP5_13TeV-powheg-pythia8_M_3500_4500_RunIISummer19UL18NanoAOD-106X_upgrade2018_realistic_v11_L1v1-v2_NANOAODSIM_skim2mu_1muPt50_1Mll100/merged/merged.root");
+  chaux_ZToMuMu_3500_4500->Add(baseDir+"/ZToMuMu_NNPDF31_TuneCP5_13TeV-powheg-pythia8_M_3500_4500_RunIISummer19UL18NanoAOD-106X_upgrade2018_realistic_v11_L1v1-v2_NANOAODSIM_skim2mu_1muPt50_1Mll100/merged/merged.root");
+  ScanChain(ch_ZToMuMu_3500_4500,getSumOfGenEventSumw(chaux_ZToMuMu_3500_4500,true),"2018","ZToMuMu_3500_4500");
 
-    ch_ZToMuMu_4500_6000->Add(baseDir+"/ZToMuMu_NNPDF31_TuneCP5_13TeV-powheg-pythia8_M_4500_6000_RunIISummer19UL18NanoAOD-106X_upgrade2018_realistic_v11_L1v1-v2_NANOAODSIM_skim2mu_1muPt50_1Mll100/merged/merged.root");
-    chaux_ZToMuMu_4500_6000->Add(baseDir+"/ZToMuMu_NNPDF31_TuneCP5_13TeV-powheg-pythia8_M_4500_6000_RunIISummer19UL18NanoAOD-106X_upgrade2018_realistic_v11_L1v1-v2_NANOAODSIM_skim2mu_1muPt50_1Mll100/merged/merged.root");
-    ScanChain(ch_ZToMuMu_4500_6000,getSumOfGenEventSumw(chaux_ZToMuMu_4500_6000,true),"2018","ZToMuMu_4500_6000");
+  ch_ZToMuMu_4500_6000->Add(baseDir+"/ZToMuMu_NNPDF31_TuneCP5_13TeV-powheg-pythia8_M_4500_6000_RunIISummer19UL18NanoAOD-106X_upgrade2018_realistic_v11_L1v1-v2_NANOAODSIM_skim2mu_1muPt50_1Mll100/merged/merged.root");
+  chaux_ZToMuMu_4500_6000->Add(baseDir+"/ZToMuMu_NNPDF31_TuneCP5_13TeV-powheg-pythia8_M_4500_6000_RunIISummer19UL18NanoAOD-106X_upgrade2018_realistic_v11_L1v1-v2_NANOAODSIM_skim2mu_1muPt50_1Mll100/merged/merged.root");
+  ScanChain(ch_ZToMuMu_4500_6000,getSumOfGenEventSumw(chaux_ZToMuMu_4500_6000,true),"2018","ZToMuMu_4500_6000");
 
-    ch_ZToMuMu_6000_Inf->Add(baseDir+"/ZToMuMu_NNPDF31_TuneCP5_13TeV-powheg-pythia8_M_6000_Inf_RunIISummer19UL18NanoAOD-106X_upgrade2018_realistic_v11_L1v1-v2_NANOAODSIM_skim2mu_1muPt50_1Mll100/merged/merged.root");
-    chaux_ZToMuMu_6000_Inf->Add(baseDir+"/ZToMuMu_NNPDF31_TuneCP5_13TeV-powheg-pythia8_M_6000_Inf_RunIISummer19UL18NanoAOD-106X_upgrade2018_realistic_v11_L1v1-v2_NANOAODSIM_skim2mu_1muPt50_1Mll100/merged/merged.root");
-    ScanChain(ch_ZToMuMu_6000_Inf,getSumOfGenEventSumw(chaux_ZToMuMu_6000_Inf,true),"2018","ZToMuMu_6000_Inf");
+  ch_ZToMuMu_6000_Inf->Add(baseDir+"/ZToMuMu_NNPDF31_TuneCP5_13TeV-powheg-pythia8_M_6000_Inf_RunIISummer19UL18NanoAOD-106X_upgrade2018_realistic_v11_L1v1-v2_NANOAODSIM_skim2mu_1muPt50_1Mll100/merged/merged.root");
+  chaux_ZToMuMu_6000_Inf->Add(baseDir+"/ZToMuMu_NNPDF31_TuneCP5_13TeV-powheg-pythia8_M_6000_Inf_RunIISummer19UL18NanoAOD-106X_upgrade2018_realistic_v11_L1v1-v2_NANOAODSIM_skim2mu_1muPt50_1Mll100/merged/merged.root");
+  ScanChain(ch_ZToMuMu_6000_Inf,getSumOfGenEventSumw(chaux_ZToMuMu_6000_Inf,true),"2018","ZToMuMu_6000_Inf");
      
-    ch2->Add(baseDir+"/WW_TuneCP5_13TeV-pythia8_RunIISummer20UL18NanoAODv9-106X_upgrade2018_realistic_v16_L1v1-v1_NANOAODSIM_skim2mu_1muPt50_1Mll100/merged/merged.root");
-    ch2aux->Add(baseDir+"/WW_TuneCP5_13TeV-pythia8_RunIISummer20UL18NanoAODv9-106X_upgrade2018_realistic_v16_L1v1-v1_NANOAODSIM_skim2mu_1muPt50_1Mll100/merged/merged.root");
-    ScanChain(ch2,getSumOfGenEventSumw(ch2aux),"2018","WW");
+  ch2->Add(baseDir+"/WW_TuneCP5_13TeV-pythia8_RunIISummer20UL18NanoAODv9-106X_upgrade2018_realistic_v16_L1v1-v1_NANOAODSIM_skim2mu_1muPt50_1Mll100/merged/merged.root");
+  ch2aux->Add(baseDir+"/WW_TuneCP5_13TeV-pythia8_RunIISummer20UL18NanoAODv9-106X_upgrade2018_realistic_v16_L1v1-v1_NANOAODSIM_skim2mu_1muPt50_1Mll100/merged/merged.root");
+  ScanChain(ch2,getSumOfGenEventSumw(ch2aux),"2018","WW");
  
-    ch3->Add(baseDir+"/WZ_TuneCP5_13TeV-pythia8_RunIISummer20UL18NanoAODv9-106X_upgrade2018_realistic_v16_L1v1-v1_NANOAODSIM_skim2mu_1muPt50_1Mll100/merged/merged.root");
-    ch3aux->Add(baseDir+"/WZ_TuneCP5_13TeV-pythia8_RunIISummer20UL18NanoAODv9-106X_upgrade2018_realistic_v16_L1v1-v1_NANOAODSIM_skim2mu_1muPt50_1Mll100/merged/merged.root");
-    ScanChain(ch3,getSumOfGenEventSumw(ch3aux),"2018","WZ");
+  ch3->Add(baseDir+"/WZ_TuneCP5_13TeV-pythia8_RunIISummer20UL18NanoAODv9-106X_upgrade2018_realistic_v16_L1v1-v1_NANOAODSIM_skim2mu_1muPt50_1Mll100/merged/merged.root");
+  ch3aux->Add(baseDir+"/WZ_TuneCP5_13TeV-pythia8_RunIISummer20UL18NanoAODv9-106X_upgrade2018_realistic_v16_L1v1-v1_NANOAODSIM_skim2mu_1muPt50_1Mll100/merged/merged.root");
+  ScanChain(ch3,getSumOfGenEventSumw(ch3aux),"2018","WZ");
    
-    ch4->Add(baseDir+"/ZZ_TuneCP5_13TeV-pythia8_RunIISummer20UL18NanoAODv9-106X_upgrade2018_realistic_v16_L1v1-v1_NANOAODSIM_skim2mu_1muPt50_1Mll100/merged/merged.root");
-    ch4aux->Add(baseDir+"/ZZ_TuneCP5_13TeV-pythia8_RunIISummer20UL18NanoAODv9-106X_upgrade2018_realistic_v16_L1v1-v1_NANOAODSIM_skim2mu_1muPt50_1Mll100/merged/merged.root");
-    ScanChain(ch4,getSumOfGenEventSumw(ch4aux),"2018","ZZ");
+  ch4->Add(baseDir+"/ZZ_TuneCP5_13TeV-pythia8_RunIISummer20UL18NanoAODv9-106X_upgrade2018_realistic_v16_L1v1-v1_NANOAODSIM_skim2mu_1muPt50_1Mll100/merged/merged.root");
+  ch4aux->Add(baseDir+"/ZZ_TuneCP5_13TeV-pythia8_RunIISummer20UL18NanoAODv9-106X_upgrade2018_realistic_v16_L1v1-v1_NANOAODSIM_skim2mu_1muPt50_1Mll100/merged/merged.root");
+  ScanChain(ch4,getSumOfGenEventSumw(ch4aux),"2018","ZZ");
 
-    ch6->Add(baseDir+"/ST_tW_top_5f_NoFullyHadronicDecays_TuneCP5_13TeV-powheg-pythia8_RunIISummer20UL18NanoAODv9-106X_upgrade2018_realistic_v16_L1v1-v1_NANOAODSIM_skim2mu_1muPt50_1Mll100/merged/merged.root");
-    ch6aux->Add(baseDir+"/ST_tW_top_5f_NoFullyHadronicDecays_TuneCP5_13TeV-powheg-pythia8_RunIISummer20UL18NanoAODv9-106X_upgrade2018_realistic_v16_L1v1-v1_NANOAODSIM_skim2mu_1muPt50_1Mll100/merged/merged.root");
-    ScanChain(ch6,getSumOfGenEventSumw(ch6aux),"2018","tW");
+  ch6->Add(baseDir+"/ST_tW_top_5f_NoFullyHadronicDecays_TuneCP5_13TeV-powheg-pythia8_RunIISummer20UL18NanoAODv9-106X_upgrade2018_realistic_v16_L1v1-v1_NANOAODSIM_skim2mu_1muPt50_1Mll100/merged/merged.root");
+  ch6aux->Add(baseDir+"/ST_tW_top_5f_NoFullyHadronicDecays_TuneCP5_13TeV-powheg-pythia8_RunIISummer20UL18NanoAODv9-106X_upgrade2018_realistic_v16_L1v1-v1_NANOAODSIM_skim2mu_1muPt50_1Mll100/merged/merged.root");
+  ScanChain(ch6,getSumOfGenEventSumw(ch6aux),"2018","tW");
 
-    ch7->Add(baseDir+"/ST_tW_antitop_5f_NoFullyHadronicDecays_TuneCP5_13TeV-powheg-pythia8_RunIISummer20UL18NanoAODv9-106X_upgrade2018_realistic_v16_L1v1-v1_NANOAODSIM_skim2mu_1muPt50_1Mll100/merged/merged.root");
-    ch7aux->Add(baseDir+"/ST_tW_antitop_5f_NoFullyHadronicDecays_TuneCP5_13TeV-powheg-pythia8_RunIISummer20UL18NanoAODv9-106X_upgrade2018_realistic_v16_L1v1-v1_NANOAODSIM_skim2mu_1muPt50_1Mll100/merged/merged.root");
-    ScanChain(ch7,getSumOfGenEventSumw(ch7aux),"2018","tbarW");
+  ch7->Add(baseDir+"/ST_tW_antitop_5f_NoFullyHadronicDecays_TuneCP5_13TeV-powheg-pythia8_RunIISummer20UL18NanoAODv9-106X_upgrade2018_realistic_v16_L1v1-v1_NANOAODSIM_skim2mu_1muPt50_1Mll100/merged/merged.root");
+  ch7aux->Add(baseDir+"/ST_tW_antitop_5f_NoFullyHadronicDecays_TuneCP5_13TeV-powheg-pythia8_RunIISummer20UL18NanoAODv9-106X_upgrade2018_realistic_v16_L1v1-v1_NANOAODSIM_skim2mu_1muPt50_1Mll100/merged/merged.root");
+  ScanChain(ch7,getSumOfGenEventSumw(ch7aux),"2018","tbarW");
     
-    ch8->Add(baseDir+"/TTWJetsToLNu_TuneCP5_13TeV-amcatnloFXFX-madspin-pythia8_RunIISummer20UL18NanoAODv9-106X_upgrade2018_realistic_v16_L1v1-v1_NANOAODSIM_skim2mu_1muPt50_1Mll100/merged/merged.root");
-    ch8aux->Add(baseDir+"/TTWJetsToLNu_TuneCP5_13TeV-amcatnloFXFX-madspin-pythia8_RunIISummer20UL18NanoAODv9-106X_upgrade2018_realistic_v16_L1v1-v1_NANOAODSIM_skim2mu_1muPt50_1Mll100/merged/merged.root");
-    ScanChain(ch8,getSumOfGenEventSumw(ch8aux),"2018","TTW");
+  ch8->Add(baseDir+"/TTWJetsToLNu_TuneCP5_13TeV-amcatnloFXFX-madspin-pythia8_RunIISummer20UL18NanoAODv9-106X_upgrade2018_realistic_v16_L1v1-v1_NANOAODSIM_skim2mu_1muPt50_1Mll100/merged/merged.root");
+  ch8aux->Add(baseDir+"/TTWJetsToLNu_TuneCP5_13TeV-amcatnloFXFX-madspin-pythia8_RunIISummer20UL18NanoAODv9-106X_upgrade2018_realistic_v16_L1v1-v1_NANOAODSIM_skim2mu_1muPt50_1Mll100/merged/merged.root");
+  ScanChain(ch8,getSumOfGenEventSumw(ch8aux),"2018","TTW");
 
-    ch9->Add(baseDir+"/TTZToLLNuNu_M-10_TuneCP5_13TeV-amcatnlo-pythia8_RunIISummer20UL18NanoAODv9-106X_upgrade2018_realistic_v16_L1v1-v1_NANOAODSIM_skim2mu_1muPt50_1Mll100/merged/merged.root");
-    ch9aux->Add(baseDir+"/TTZToLLNuNu_M-10_TuneCP5_13TeV-amcatnlo-pythia8_RunIISummer20UL18NanoAODv9-106X_upgrade2018_realistic_v16_L1v1-v1_NANOAODSIM_skim2mu_1muPt50_1Mll100/merged/merged.root");
-    ScanChain(ch9,getSumOfGenEventSumw(ch9aux),"2018","TTZ");
+  ch9->Add(baseDir+"/TTZToLLNuNu_M-10_TuneCP5_13TeV-amcatnlo-pythia8_RunIISummer20UL18NanoAODv9-106X_upgrade2018_realistic_v16_L1v1-v1_NANOAODSIM_skim2mu_1muPt50_1Mll100/merged/merged.root");
+  ch9aux->Add(baseDir+"/TTZToLLNuNu_M-10_TuneCP5_13TeV-amcatnlo-pythia8_RunIISummer20UL18NanoAODv9-106X_upgrade2018_realistic_v16_L1v1-v1_NANOAODSIM_skim2mu_1muPt50_1Mll100/merged/merged.root");
+  ScanChain(ch9,getSumOfGenEventSumw(ch9aux),"2018","TTZ");
     
-    ch10->Add(baseDir+"/ttHJetToNonbb_M125_TuneCP5_13TeV_amcatnloFXFX_madspin_pythia8_RunIISummer20UL18NanoAODv9-106X_upgrade2018_realistic_v16_L1v1-v1_NANOAODSIM_skim2mu_1muPt50_1Mll100/merged/merged.root");
-    ch10aux->Add(baseDir+"/ttHJetToNonbb_M125_TuneCP5_13TeV_amcatnloFXFX_madspin_pythia8_RunIISummer20UL18NanoAODv9-106X_upgrade2018_realistic_v16_L1v1-v1_NANOAODSIM_skim2mu_1muPt50_1Mll100/merged/merged.root");
-    ScanChain(ch10,getSumOfGenEventSumw(ch10aux),"2018","TTHToNonbb");
+  ch10->Add(baseDir+"/ttHJetToNonbb_M125_TuneCP5_13TeV_amcatnloFXFX_madspin_pythia8_RunIISummer20UL18NanoAODv9-106X_upgrade2018_realistic_v16_L1v1-v1_NANOAODSIM_skim2mu_1muPt50_1Mll100/merged/merged.root");
+  ch10aux->Add(baseDir+"/ttHJetToNonbb_M125_TuneCP5_13TeV_amcatnloFXFX_madspin_pythia8_RunIISummer20UL18NanoAODv9-106X_upgrade2018_realistic_v16_L1v1-v1_NANOAODSIM_skim2mu_1muPt50_1Mll100/merged/merged.root");
+  ScanChain(ch10,getSumOfGenEventSumw(ch10aux),"2018","TTHToNonbb");
     
-    //ch11->Add("");
-    //ch11aux->Add("");
-    //ScanChain(ch11,getSumOfGenEventSumw(ch11aux),"2018","TTHTobb");
+  //ch11->Add("");
+  //ch11aux->Add("");
+  //ScanChain(ch11,getSumOfGenEventSumw(ch11aux),"2018","TTHTobb");
  
-    // Signal Y3, 2018
-    ch_Y3_M100->Add(baseSignalDir+"/ZPrimeToMuMuSB_M100_bestfit_TuneCP5_13TeV_Allanach_Y3_5f_madgraph_pythia8_NoPSWgts_RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v2_private_NANOAODSIM_skim2mu_1muPt50_1Mll100_PrivSignal/merged/merged.root");
-    chaux_Y3_M100->Add(baseSignalDir+"/ZPrimeToMuMuSB_M100_bestfit_TuneCP5_13TeV_Allanach_Y3_5f_madgraph_pythia8_NoPSWgts_RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v2_private_NANOAODSIM_skim2mu_1muPt50_1Mll100_PrivSignal/merged/merged.root");
-    ScanChain(ch_Y3_M100,getSumOfGenEventSumw(chaux_Y3_M100),"2018","Y3_M100");
+  // Signal Y3, 2018
+  ch_Y3_M100->Add(baseSignalDir+"/ZPrimeToMuMuSB_M100_bestfit_TuneCP5_13TeV_Allanach_Y3_5f_madgraph_pythia8_NoPSWgts_RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v2_private_NANOAODSIM_skim2mu_1muPt50_1Mll100_PrivSignal/merged/merged.root");
+  chaux_Y3_M100->Add(baseSignalDir+"/ZPrimeToMuMuSB_M100_bestfit_TuneCP5_13TeV_Allanach_Y3_5f_madgraph_pythia8_NoPSWgts_RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v2_private_NANOAODSIM_skim2mu_1muPt50_1Mll100_PrivSignal/merged/merged.root");
+  ScanChain(ch_Y3_M100,getSumOfGenEventSumw(chaux_Y3_M100),"2018","Y3_M100");
 
-    ch5->Add(baseSignalDir+"/ZPrimeToMuMuSB_M200_bestfit_TuneCP5_13TeV_Allanach_Y3_5f_madgraph_pythia8_NoPSWgts_RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v2_private_NANOAODSIM_skim2mu_1muPt50_1Mll100_PrivSignal/merged/merged.root");
-    ch5aux->Add(baseSignalDir+"/ZPrimeToMuMuSB_M200_bestfit_TuneCP5_13TeV_Allanach_Y3_5f_madgraph_pythia8_NoPSWgts_RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v2_private_NANOAODSIM_skim2mu_1muPt50_1Mll100_PrivSignal/merged/merged.root");
-    ScanChain(ch5,getSumOfGenEventSumw(ch5aux),"2018","Y3_M200");
+  ch5->Add(baseSignalDir+"/ZPrimeToMuMuSB_M200_bestfit_TuneCP5_13TeV_Allanach_Y3_5f_madgraph_pythia8_NoPSWgts_RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v2_private_NANOAODSIM_skim2mu_1muPt50_1Mll100_PrivSignal/merged/merged.root");
+  ch5aux->Add(baseSignalDir+"/ZPrimeToMuMuSB_M200_bestfit_TuneCP5_13TeV_Allanach_Y3_5f_madgraph_pythia8_NoPSWgts_RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v2_private_NANOAODSIM_skim2mu_1muPt50_1Mll100_PrivSignal/merged/merged.root");
+  ScanChain(ch5,getSumOfGenEventSumw(ch5aux),"2018","Y3_M200");
 
-    ch_Y3_M400->Add(baseSignalDir+"/ZPrimeToMuMuSB_M400_bestfit_TuneCP5_13TeV_Allanach_Y3_5f_madgraph_pythia8_NoPSWgts_RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v2_private_NANOAODSIM_skim2mu_1muPt50_1Mll100_PrivSignal/merged/merged.root");
-    chaux_Y3_M400->Add(baseSignalDir+"/ZPrimeToMuMuSB_M400_bestfit_TuneCP5_13TeV_Allanach_Y3_5f_madgraph_pythia8_NoPSWgts_RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v2_private_NANOAODSIM_skim2mu_1muPt50_1Mll100_PrivSignal/merged/merged.root");
-    ScanChain(ch_Y3_M400,getSumOfGenEventSumw(chaux_Y3_M400),"2018","Y3_M400");
+  ch_Y3_M400->Add(baseSignalDir+"/ZPrimeToMuMuSB_M400_bestfit_TuneCP5_13TeV_Allanach_Y3_5f_madgraph_pythia8_NoPSWgts_RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v2_private_NANOAODSIM_skim2mu_1muPt50_1Mll100_PrivSignal/merged/merged.root");
+  chaux_Y3_M400->Add(baseSignalDir+"/ZPrimeToMuMuSB_M400_bestfit_TuneCP5_13TeV_Allanach_Y3_5f_madgraph_pythia8_NoPSWgts_RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v2_private_NANOAODSIM_skim2mu_1muPt50_1Mll100_PrivSignal/merged/merged.root");
+  ScanChain(ch_Y3_M400,getSumOfGenEventSumw(chaux_Y3_M400),"2018","Y3_M400");
 
-    ch_Y3_M700->Add(baseSignalDir+"/ZPrimeToMuMuSB_M700_bestfit_TuneCP5_13TeV_Allanach_Y3_5f_madgraph_pythia8_NoPSWgts_RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v2_private_NANOAODSIM_skim2mu_1muPt50_1Mll100_PrivSignal/merged/merged.root");
-    chaux_Y3_M700->Add(baseSignalDir+"/ZPrimeToMuMuSB_M700_bestfit_TuneCP5_13TeV_Allanach_Y3_5f_madgraph_pythia8_NoPSWgts_RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v2_private_NANOAODSIM_skim2mu_1muPt50_1Mll100_PrivSignal/merged/merged.root");
-    ScanChain(ch_Y3_M700,getSumOfGenEventSumw(chaux_Y3_M700),"2018","Y3_M700");
+  ch_Y3_M700->Add(baseSignalDir+"/ZPrimeToMuMuSB_M700_bestfit_TuneCP5_13TeV_Allanach_Y3_5f_madgraph_pythia8_NoPSWgts_RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v2_private_NANOAODSIM_skim2mu_1muPt50_1Mll100_PrivSignal/merged/merged.root");
+  chaux_Y3_M700->Add(baseSignalDir+"/ZPrimeToMuMuSB_M700_bestfit_TuneCP5_13TeV_Allanach_Y3_5f_madgraph_pythia8_NoPSWgts_RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v2_private_NANOAODSIM_skim2mu_1muPt50_1Mll100_PrivSignal/merged/merged.root");
+  ScanChain(ch_Y3_M700,getSumOfGenEventSumw(chaux_Y3_M700),"2018","Y3_M700");
 
-    ch_Y3_M1000->Add(baseSignalDir+"/ZPrimeToMuMuSB_M1000_bestfit_TuneCP5_13TeV_Allanach_Y3_5f_madgraph_pythia8_NoPSWgts_RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v2_private_NANOAODSIM_skim2mu_1muPt50_1Mll100_PrivSignal/merged/merged.root");
-    chaux_Y3_M1000->Add(baseSignalDir+"/ZPrimeToMuMuSB_M1000_bestfit_TuneCP5_13TeV_Allanach_Y3_5f_madgraph_pythia8_NoPSWgts_RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v2_private_NANOAODSIM_skim2mu_1muPt50_1Mll100_PrivSignal/merged/merged.root");
-    ScanChain(ch_Y3_M1000,getSumOfGenEventSumw(chaux_Y3_M1000),"2018","Y3_M1000");
+  ch_Y3_M1000->Add(baseSignalDir+"/ZPrimeToMuMuSB_M1000_bestfit_TuneCP5_13TeV_Allanach_Y3_5f_madgraph_pythia8_NoPSWgts_RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v2_private_NANOAODSIM_skim2mu_1muPt50_1Mll100_PrivSignal/merged/merged.root");
+  chaux_Y3_M1000->Add(baseSignalDir+"/ZPrimeToMuMuSB_M1000_bestfit_TuneCP5_13TeV_Allanach_Y3_5f_madgraph_pythia8_NoPSWgts_RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v2_private_NANOAODSIM_skim2mu_1muPt50_1Mll100_PrivSignal/merged/merged.root");
+  ScanChain(ch_Y3_M1000,getSumOfGenEventSumw(chaux_Y3_M1000),"2018","Y3_M1000");
 
-    ch_Y3_M1500->Add(baseSignalDir+"/ZPrimeToMuMuSB_M1500_bestfit_TuneCP5_13TeV_Allanach_Y3_5f_madgraph_pythia8_NoPSWgts_RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v2_private_NANOAODSIM_skim2mu_1muPt50_1Mll100_PrivSignal/merged/merged.root");
-    chaux_Y3_M1500->Add(baseSignalDir+"/ZPrimeToMuMuSB_M1500_bestfit_TuneCP5_13TeV_Allanach_Y3_5f_madgraph_pythia8_NoPSWgts_RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v2_private_NANOAODSIM_skim2mu_1muPt50_1Mll100_PrivSignal/merged/merged.root");
-    ScanChain(ch_Y3_M1500,getSumOfGenEventSumw(chaux_Y3_M1500),"2018","Y3_M1500");
+  ch_Y3_M1500->Add(baseSignalDir+"/ZPrimeToMuMuSB_M1500_bestfit_TuneCP5_13TeV_Allanach_Y3_5f_madgraph_pythia8_NoPSWgts_RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v2_private_NANOAODSIM_skim2mu_1muPt50_1Mll100_PrivSignal/merged/merged.root");
+  chaux_Y3_M1500->Add(baseSignalDir+"/ZPrimeToMuMuSB_M1500_bestfit_TuneCP5_13TeV_Allanach_Y3_5f_madgraph_pythia8_NoPSWgts_RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v2_private_NANOAODSIM_skim2mu_1muPt50_1Mll100_PrivSignal/merged/merged.root");
+  ScanChain(ch_Y3_M1500,getSumOfGenEventSumw(chaux_Y3_M1500),"2018","Y3_M1500");
 
-    ch_Y3_M2000->Add(baseSignalDir+"/ZPrimeToMuMuSB_M2000_bestfit_TuneCP5_13TeV_Allanach_Y3_5f_madgraph_pythia8_NoPSWgts_RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v2_private_NANOAODSIM_skim2mu_1muPt50_1Mll100_PrivSignal/merged/merged.root");
-    chaux_Y3_M2000->Add(baseSignalDir+"/ZPrimeToMuMuSB_M2000_bestfit_TuneCP5_13TeV_Allanach_Y3_5f_madgraph_pythia8_NoPSWgts_RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v2_private_NANOAODSIM_skim2mu_1muPt50_1Mll100_PrivSignal/merged/merged.root");
-    ScanChain(ch_Y3_M2000,getSumOfGenEventSumw(chaux_Y3_M2000),"2018","Y3_M2000");
+  ch_Y3_M2000->Add(baseSignalDir+"/ZPrimeToMuMuSB_M2000_bestfit_TuneCP5_13TeV_Allanach_Y3_5f_madgraph_pythia8_NoPSWgts_RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v2_private_NANOAODSIM_skim2mu_1muPt50_1Mll100_PrivSignal/merged/merged.root");
+  chaux_Y3_M2000->Add(baseSignalDir+"/ZPrimeToMuMuSB_M2000_bestfit_TuneCP5_13TeV_Allanach_Y3_5f_madgraph_pythia8_NoPSWgts_RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v2_private_NANOAODSIM_skim2mu_1muPt50_1Mll100_PrivSignal/merged/merged.root");
+  ScanChain(ch_Y3_M2000,getSumOfGenEventSumw(chaux_Y3_M2000),"2018","Y3_M2000");
 
 }
 
 double getSumOfGenEventSumw(TChain *chaux, bool useUnderscore=false)
 {
-    double genEventSumw, sumOfGenEventSumw=0.0;
-    if (useUnderscore) chaux->SetBranchAddress("genEventSumw_",&genEventSumw);
-    else chaux->SetBranchAddress("genEventSumw",&genEventSumw);
-    for (unsigned int run = 0; run < chaux->GetEntriesFast(); run++)
+  double genEventSumw, sumOfGenEventSumw=0.0;
+  if (useUnderscore) chaux->SetBranchAddress("genEventSumw_",&genEventSumw);
+  else chaux->SetBranchAddress("genEventSumw",&genEventSumw);
+  for (unsigned int run = 0; run < chaux->GetEntriesFast(); run++)
     {
-        chaux->GetEntry(run);
-        sumOfGenEventSumw += genEventSumw;
+      chaux->GetEntry(run);
+      sumOfGenEventSumw += genEventSumw;
     }
 
-    return sumOfGenEventSumw;
+  return sumOfGenEventSumw;
 }
 

--- a/python/make_cutflow_table.py
+++ b/python/make_cutflow_table.py
@@ -72,6 +72,7 @@ def make_table(samples, indir = "./cpp/temp_data/", year = "2018", outdir="table
     fout.write('\\usepackage{adjustbox}\n')
     fout.write('\\thispagestyle{empty}\n')
     fout.write('\\begin{document}\n')
+    fout.write('{\\tiny{Skim: $\\geq 2\\mu$, $\\geq 1\\mu$ with p$_\\mathrm{T}>50$ GeV and $\\geq$ 1 pair with m(ll) $>$ 90 GeV.}')
     fout.write('\\begin{table*}[h]\n')
     fout.write('\\footnotesize\n')
     fout.write('\\begin{adjustbox}{width=\\textwidth}\n')
@@ -99,7 +100,7 @@ def make_table(samples, indir = "./cpp/temp_data/", year = "2018", outdir="table
         tlabel = tlabel.replace("$$","$ $")
         fout.write(tlabel)
         for i in range(len(samples)):
-            fout.write('& %.3E & %.2f'%(yields[i][c],100.0*effs[i][c]))
+            fout.write('& %.3E & %.2E'%(yields[i][c],100.0*effs[i][c]))
         fout.write('\\\\\n')
     
     fout.write('\\end{tabular}\n')

--- a/python/make_cutflow_table.py
+++ b/python/make_cutflow_table.py
@@ -96,6 +96,7 @@ def make_table(samples=[], sampleLabels=[], indir = "./cpp/temp_data/", year = "
     for c in range(nCuts):
         tlabel = labels[c]
         tlabel = tlabel.replace("pT","$p_{\\mathrm{T}}$")
+        tlabel = tlabel.replace("dR","$\\Delta$R")
         tlabel = tlabel.replace("&","and")
         tlabel = tlabel.replace("|eta|","$|\\eta|$")
         tlabel = tlabel.replace(">","$>$")

--- a/python/make_cutflow_table.py
+++ b/python/make_cutflow_table.py
@@ -75,7 +75,7 @@ def make_table(samples=[], sampleLabels=[], indir = "./cpp/temp_data/", year = "
     fout.write('\\usepackage{adjustbox}\n')
     fout.write('\\thispagestyle{empty}\n')
     fout.write('\\begin{document}\n')
-    fout.write('{\\tiny{Skim: $\\geq 2\\mu$, $\\geq 1\\mu$ with p$_\\mathrm{T}>50$ GeV and $\\geq$ 1 pair with m(ll) $>$ 90 GeV.}')
+    fout.write('{\\tiny{Skim: $\\geq 2\\mu$, $\\geq 1\\mu$ with p$_\\mathrm{T}>50$ GeV and $\\geq$ 1 pair with m(ll) $>$ 100 GeV.}')
     fout.write('\\begin{table*}[h]\n')
     fout.write('\\footnotesize\n')
     fout.write('\\begin{adjustbox}{width=\\textwidth}\n')

--- a/python/make_cutflow_table.py
+++ b/python/make_cutflow_table.py
@@ -8,10 +8,13 @@ import ROOT
 ### pdfcrop --margins '0 0' <filename>.pdf
 ### mv <filename-crop>.pdf <filename>.pdf 
 
-def make_table(samples, indir = "./cpp/temp_data/", year = "2018", outdir="tables/"):
-    
+def make_table(samples=[], sampleLabels=[], indir = "./cpp/temp_data/", year = "2018", outdir="tables/"):
+
     if not os.path.exists(outdir):
         os.makedirs(outdir)
+
+    if len(sampleLabels)<len(samples):
+        sampleLabels = samples
 
     nCuts = 0
     yields = []
@@ -21,7 +24,7 @@ def make_table(samples, indir = "./cpp/temp_data/", year = "2018", outdir="table
         yields.append([])
         effs  .append([])
         subsamples = []
-        if samples[i]=='DY':
+        if samples[i]=='ZToMuMu':
             subsamples = ['ZToMuMu_50_120',
                           'ZToMuMu_120_200',
                           'ZToMuMu_200_400',
@@ -83,7 +86,7 @@ def make_table(samples, indir = "./cpp/temp_data/", year = "2018", outdir="table
     fout.write('|}\n')
     fout.write('Selection ')
     for i in range(len(samples)):
-        fout.write('& \multicolumn{2}{|c|}{'+samples[i].replace("_"," ")+'}')
+        fout.write('& \multicolumn{2}{|c|}{'+sampleLabels[i].replace("_"," ")+'}')
     fout.write('\\\\\n')
     for i in range(len(samples)):
         fout.write('& Yield & Eff. (\%)')
@@ -110,6 +113,11 @@ def make_table(samples, indir = "./cpp/temp_data/", year = "2018", outdir="table
 
     fout.close()
 
-samples=['ttbar','tW','ttX','DY','VV']
+# SM backgrounds
+samples=['ttbar','tW','ttX','ZToMuMu','VV']
+sampleLabels=["t$\\bar{\\mathrm{t}}$","tW","t$\\bar{\\mathrm{t}}$X","DY($\\mu\\mu$)","VV (V$=$Z,W)"]
+
+# Signal
 samples=samples+['Y3_M200','Y3_M400','Y3_M700','Y3_M1000','Y3_M1500','Y3_M2000']
-make_table(samples)
+sampleLabels=sampleLabels+["Y3 (200 GeV)","Y3 (400 GeV)","Y3 (700 GeV)","Y3 (1000 GeV)","Y3 (1500 GeV)","Y3 (2000 GeV)"]
+make_table(samples,sampleLabels)

--- a/python/stack_plots.py
+++ b/python/stack_plots.py
@@ -39,8 +39,11 @@ def get_plot(plotFile, plotname, fillColor=None, lineColor=None, lineWidth=0):
 
     if fillColor: 
         plot.SetFillColor(fillColor)
+        plot.SetLineColor(fillColor)
+        plot.SetMarkerColor(fillColor)
     if lineColor: 
         plot.SetLineColor(lineColor)
+        plot.SetMarkerColor(lineColor)
     plot.SetLineWidth(lineWidth)
     #plot.Sumw2()
 
@@ -109,7 +112,8 @@ def draw_plot(plotname="fatjet_msoftdrop", title="myTitle", log=True, compare_da
                 signalplots[i].Scale(1.0/signalplots[i].GetBinContent(1))
     for i in range(len(ZToMuMufiles)): 
         ZToMuMuplots.append(get_plot(ZToMuMufiles[i],plotname,fillColor=ROOT.kOrange))
-    if compare_data: dataplot = get_plot(datafile,plotname,lineColor=ROOT.kBlack,lineWidth=2)
+    if compare_data: 
+        dataplot = get_plot(datafile,plotname,lineColor=ROOT.kBlack,lineWidth=2)
     WWplot = get_plot(WWfile,plotname,fillColor=ROOT.kOrange+1)
     WZplot = get_plot(WZfile,plotname,fillColor=ROOT.kOrange+2)
     ZZplot = get_plot(ZZfile,plotname,fillColor=ROOT.kOrange+3)
@@ -169,19 +173,19 @@ def draw_plot(plotname="fatjet_msoftdrop", title="myTitle", log=True, compare_da
 
     for i,mass in enumerate(args.signalMass): 
         if log==False and args.signalScale and not args.shape:
-            legend.AddEntry(signalplots[i],"Y3 ("+str(mass)+" GeV) %1.2E x%1.1E"%(signalplots[i].Integral(0,-1),(float(args.signalScale))*(float(signalXSecScale[str(mass)]))))
+            legend.AddEntry(signalplots[i],"Y3 ("+str(mass)+" GeV) %1.2E x%1.1E"%(signalplots[i].Integral(0,-1),(float(args.signalScale))*(float(signalXSecScale[str(mass)]))),"L")
         else:
-            legend.AddEntry(signalplots[i],"Y3 ("+str(mass)+" GeV) %1.2E"%(signalplots[i].Integral(0,-1)))
+            legend.AddEntry(signalplots[i],"Y3 ("+str(mass)+" GeV) %1.2E"%(signalplots[i].Integral(0,-1)),"L")
             
     if compare_data: 
-        legend.AddEntry(dataplot,"data %1.2E"%(dataplot.Integral(0,-1)))
-    legend.AddEntry(ZToMuMuplot, "DY(#mu#mu) %1.2E"%(ZToMuMuplot.Integral(0,-1)))
-    legend.AddEntry(ttbarplot,"t#bar{t} %1.2E"%(ttbarplot.Integral(0,-1)))
-    legend.AddEntry(tWplot,"tW %1.2E"%(ST_tWplot.Integral(0,-1)))
-    legend.AddEntry(TTXplot,"t#bar{t}X %1.2E"%(TTXplot.Integral(0,-1)))
-    legend.AddEntry(WWplot, "WW %1.2E"%(WWplot.Integral(0,-1)))
-    legend.AddEntry(WZplot, "WZ %1.2E"%(WZplot.Integral(0,-1)))
-    legend.AddEntry(ZZplot,"ZZ %1.2E"%(ZZplot.Integral(0,-1)))
+        legend.AddEntry(dataplot,"data %1.2E"%(dataplot.Integral(0,-1)),"PL")
+    legend.AddEntry(ZToMuMuplot, "DY(#mu#mu) %1.2E"%(ZToMuMuplot.Integral(0,-1)),"F")
+    legend.AddEntry(ttbarplot,"t#bar{t} %1.2E"%(ttbarplot.Integral(0,-1)),"F")
+    legend.AddEntry(tWplot,"tW %1.2E"%(ST_tWplot.Integral(0,-1)),"F")
+    legend.AddEntry(TTXplot,"t#bar{t}X %1.2E"%(TTXplot.Integral(0,-1)),"F")
+    legend.AddEntry(WWplot, "WW %1.2E"%(WWplot.Integral(0,-1)),"F")
+    legend.AddEntry(WZplot, "WZ %1.2E"%(WZplot.Integral(0,-1)),"F")
+    legend.AddEntry(ZZplot,"ZZ %1.2E"%(ZZplot.Integral(0,-1)),"F")
 
     #define canvas
     canvas = ROOT.TCanvas("canvas","canvas",800,800)
@@ -216,12 +220,14 @@ def draw_plot(plotname="fatjet_msoftdrop", title="myTitle", log=True, compare_da
     #plot data,stack, signal, data  
     stack.Draw("HIST")
     if "cutflow" in plotname:
-        stack.GetXaxis().SetLabelSize(0.025)
+        stack.GetXaxis().SetLabelSize(0.023)
     else:
         stack.GetXaxis().SetTitle(totalSM.GetXaxis().GetTitle())
-        stack.GetYaxis().SetTitle(totalSM.GetYaxis().GetTitle())
-        stack.GetYaxis().SetLabelSize(0.03)
-        stack.GetYaxis().SetMaxDigits(3)
+    stack.GetYaxis().SetTitle(totalSM.GetYaxis().GetTitle())
+    if args.shape:
+        stack.GetYaxis().SetTitle("A.U.")
+    stack.GetYaxis().SetLabelSize(0.03)
+    stack.GetYaxis().SetMaxDigits(3)
     histMax = 0.0
     for i,mass in enumerate(args.signalMass):
         if log==False and args.signalScale and not args.shape: 

--- a/python/stack_plots.py
+++ b/python/stack_plots.py
@@ -54,7 +54,6 @@ def draw_plot(plotname="fatjet_msoftdrop", title="myTitle", log=True, compare_da
         signalfiles.append(ROOT.TFile(args.inDir+"output_Y3_M"+str(mass)+"_2018.root"))
     for m1,m2 in zip(["50","120","200","400","800","1400","2300","3500","4500","6000"],["120","200","400","800","1400","2300","3500","4500","6000","Inf"]): 
         ZToMuMufiles.append(ROOT.TFile(args.inDir+"output_ZToMuMu_"+m1+"_"+m2+"_2018.root"))
-    #DYfile =     ROOT.TFile(args.inDir+"output_DY_2018.root")
     WWfile =     ROOT.TFile(args.inDir+"output_WW_2018.root")
     WZfile =     ROOT.TFile(args.inDir+"output_WZ_2018.root")
     ZZfile =     ROOT.TFile(args.inDir+"output_ZZ_2018.root")
@@ -64,7 +63,6 @@ def draw_plot(plotname="fatjet_msoftdrop", title="myTitle", log=True, compare_da
     TTWfile =    ROOT.TFile(args.inDir+"output_TTW_2018.root")
     TTZfile =    ROOT.TFile(args.inDir+"output_TTZ_2018.root")
     TTHNobbfile= ROOT.TFile(args.inDir+"output_TTHToNonbb_2018.root")
-    #TTHbbfile =  ROOT.TFile(args.inDir+"output_TTHTobb_2018.root")
     if compare_data: 
         datafile = ROOT.TFile(args.inDir+"data_2018_2_selected.root")
 
@@ -81,7 +79,6 @@ def draw_plot(plotname="fatjet_msoftdrop", title="myTitle", log=True, compare_da
     for i in range(len(ZToMuMufiles)): 
         ZToMuMuplots.append(get_plot(ZToMuMufiles[i],plotname,fillColor=ROOT.kOrange))
     if compare_data: dataplot = get_plot(datafile,plotname,lineColor=ROOT.kBlack,lineWidth=2)
-    #DYplot = get_plot(DYfile,plotname,fillColor=ROOT.kOrange)
     WWplot = get_plot(WWfile,plotname,fillColor=ROOT.kOrange+1)
     WZplot = get_plot(WZfile,plotname,fillColor=ROOT.kOrange+2)
     ZZplot = get_plot(ZZfile,plotname,fillColor=ROOT.kOrange+3)
@@ -91,7 +88,6 @@ def draw_plot(plotname="fatjet_msoftdrop", title="myTitle", log=True, compare_da
     TTWplot = get_plot(TTWfile,plotname,fillColor=ROOT.kOrange+6)
     TTZplot = get_plot(TTZfile,plotname,fillColor=ROOT.kOrange+6)
     TTHNobbplot = get_plot(TTHNobbfile,plotname,fillColor=ROOT.kOrange+6)
-    #TTHbbplot = TTHbbfile.Get(plotname)
    
     #add histos
     ZToMuMuplot = ZToMuMuplots[0].Clone("ZToMuMu")
@@ -129,42 +125,27 @@ def draw_plot(plotname="fatjet_msoftdrop", title="myTitle", log=True, compare_da
     stack.Add(WZplot)
     stack.Add(WWplot)
     stack.Add(TTXplot)
-    #stack.Add(TTWplot)
-    #stack.Add(TTZplot)
-    #stack.Add(TTHNobbplot)
-    #stack.Add(TTHbbplot)
     stack.Add(ST_tWplot)
-    #stack.Add(tWplot)
-    #stack.Add(tbarWplot)
     stack.Add(ttbarplot)
     stack.Add(ZToMuMuplot)
-    #stack.Add(DYplot)
     stack.SetTitle(title)
 
     #plot legends, ranges
     legend = ROOT.TLegend(0.65,0.65,0.97,0.97)
-    legend.SetTextFont(60)
-    legend.SetTextSize(0.02)
+    #legend.SetTextSize(0.02)
 
     for i,mass in enumerate(args.signalMass): 
         if log==False and args.signalScale and not args.shape:
-            legend.AddEntry(signalplots[i],"Y3_M"+str(mass)+" %1.2E x%1.1E"%(signalplots[i].Integral(0,-1),(float(args.signalScale))*(float(signalXSecScale[str(mass)]))))
+            legend.AddEntry(signalplots[i],"Y3 ("+str(mass)+" GeV) %1.2E x%1.1E"%(signalplots[i].Integral(0,-1),(float(args.signalScale))*(float(signalXSecScale[str(mass)]))))
         else:
-            legend.AddEntry(signalplots[i],"Y3_M"+str(mass)+" %1.2E"%(signalplots[i].Integral(0,-1)))
+            legend.AddEntry(signalplots[i],"Y3 ("+str(mass)+" GeV) %1.2E"%(signalplots[i].Integral(0,-1)))
             
     if compare_data: 
         legend.AddEntry(dataplot,"data %1.2E"%(dataplot.Integral(0,-1)))
-    legend.AddEntry(ZToMuMuplot, "ZToMuMu %1.2E"%(ZToMuMuplot.Integral(0,-1)))
-    #legend.AddEntry(DYplot, "DY %1.2E"%(DYplot.Integral(0,-1)))
+    legend.AddEntry(ZToMuMuplot, "DY(#mu#mu) %1.2E"%(ZToMuMuplot.Integral(0,-1)))
     legend.AddEntry(ttbarplot,"t#bar{t} %1.2E"%(ttbarplot.Integral(0,-1)))
     legend.AddEntry(tWplot,"tW %1.2E"%(ST_tWplot.Integral(0,-1)))
-    #legend.AddEntry(tWplot,"tW %1.2E"%(tWplot.Integral(0,-1)))
-    #legend.AddEntry(tbarWplot,"tbarW %1.2E"%(tbarWplot.Integral(0,-1)))
     legend.AddEntry(TTXplot,"t#bar{t}X %1.2E"%(TTXplot.Integral(0,-1)))
-    #legend.AddEntry(TTWplot,"ttW %1.2E"%(TTWplot.Integral(0,-1)))
-    #legend.AddEntry(TTZplot,"ttZ %1.2E"%(TTZplot.Integral(0,-1)))
-    #legend.AddEntry(TTHNobbplot,"ttHNobb %1.2E"%(TTHNobbplot.Integral(0,-1)))
-    #legend.AddEntry(TTHbbplot,"ttHbb %1.2E"%(TTHbbplot.Integral(0,-1))) 
     legend.AddEntry(WWplot, "WW %1.2E"%(WWplot.Integral(0,-1)))
     legend.AddEntry(WZplot, "WZ %1.2E"%(WZplot.Integral(0,-1)))
     legend.AddEntry(ZZplot,"ZZ %1.2E"%(ZZplot.Integral(0,-1)))
@@ -173,7 +154,6 @@ def draw_plot(plotname="fatjet_msoftdrop", title="myTitle", log=True, compare_da
     canvas = ROOT.TCanvas("canvas","canvas",800,800)
 
     if DoRatio==True:
-        #MCplot = copy.deepcopy(DYplot)
         MCplot = copy.deepcopy(ZToMuMuplot)
         MCplot.Add(WWplot)
         MCplot.Add(WZplot)
@@ -220,6 +200,8 @@ def draw_plot(plotname="fatjet_msoftdrop", title="myTitle", log=True, compare_da
         #stack.Draw("Hist")
 
     legend.Draw()
+
+    canvas.Update()
 
     #print and save
     extension = ""


### PR DESCRIPTION
This PR introduces:
(1) usage of exponential notation for cutflow table efficiency;
(2) start mll distribution from 90 GeV (as for skim);
(3) use dR<0.05 for dR(trigger object, muon), based on [distribution](http://uaf-10.t2.ucsd.edu/~mmasciov/Zprime/plots_Apr-17-2022/dr_trigobj_sel3_s+b_log.png) - was 0.2 originally;
(4) fix dxy/dz requirements for extra leptons using fabs for sign;
(5) implementation of IsoTrack veto (available in new skims);
(6) switch to new skims (without pruning);
(7) optionality for spike removal (disabled);
(8) possibility to produce area-normalized plots;
(9) consistent indentation ([4d16a27](https://github.com/cmstas/ZPrimeSnT/pull/9/commits/4d16a279ddbd68683333176406d44a763e1e8e94)).

For the review, please go by commit, since commit [4d16a27](https://github.com/cmstas/ZPrimeSnT/pull/9/commits/4d16a279ddbd68683333176406d44a763e1e8e94) modifies the indentation across the full files.

Plots: http://uaf-10.t2.ucsd.edu/~mmasciov/Zprime/plots_Apr-17-2022/
Cutflow table: http://uaf-10.t2.ucsd.edu/~mmasciov/Zprime/plots_Apr-17-2022/cutflow_2018.pdf
