### PR TITLE
Revamp plotting script

### DIFF
--- a/python/stack_plots.py
+++ b/python/stack_plots.py
@@ -1,7 +1,4 @@
-from curses import can_change_color
-from hashlib import new
-from numbers import Integral
-from tkinter.tix import Tree
+from collections import OrderedDict
 import ROOT
 import copy
 import argparse
@@ -31,6 +28,8 @@ os.system('cp '+args.inDir+'../../utils/index.php '+args.outDir)
 if len(args.signalMass)==0: 
     args.signalMass = [200,400,700,1000,1500,2000]
 
+
+# Selection
 sels = []
 sels.append("N_{#mu}#geq 2, p_{T}^{#mu_{1}}>50 GeV, m_{#mu#mu}>100 GeV")
 sels.append("HLT selection")
@@ -71,10 +70,117 @@ mllbin["mll1100to1900"]="1.1 < m_{#mu#mu} < 1.9 TeV"
 mllbin["mll1500to2500"]="1.5 < m_{#mu#mu} < 2.5 TeV"
 
 
+# Samples
+samples=[]
+# data to be added
+samples.append("Y3")
+samples.append("ZToMuMu")
+samples.append("ttbar")
+samples.append("tW")
+samples.append("tbarW")
+samples.append("TTW")
+samples.append("TTZ")
+samples.append("TTHToNonbb")
+samples.append("TTHTobb")
+samples.append("WW")
+samples.append("ZZ")
+samples.append("WZ")
 
-def get_plot(plotFile, plotname, fillColor=None, lineColor=None, lineWidth=0):
-    plot = plotFile.Get(plotname)
+sampleFillColor=dict()
+# data to be added
+sampleFillColor["Y3"]       = None
+sampleFillColor["ZToMuMu"]  = ROOT.kGreen+1
+sampleFillColor["ttbar"]    = ROOT.kAzure+1
+sampleFillColor["ST_tW"]    = ROOT.kAzure+2
+sampleFillColor["TTX"]      = ROOT.kAzure+4
+sampleFillColor["WW"]       = ROOT.kOrange-3
+sampleFillColor["ZZ"]       = ROOT.kOrange-2
+sampleFillColor["WZ"]       = ROOT.kOrange-1
 
+sampleLineColor=dict()
+# data to be added
+sampleLineColor["Y3"]       = ROOT.kViolet-9
+sampleLineColor["ZToMuMu"]  = None
+sampleLineColor["ttbar"]    = None
+sampleLineColor["ST_tW"]    = None
+sampleLineColor["TTX"]      = None
+sampleLineColor["WW"]       = None
+sampleLineColor["ZZ"]       = None
+sampleLineColor["WZ"]       = None
+
+sampleLineWidth=dict()
+# data to be added
+sampleLineWidth["Y3"]       = 2
+sampleLineWidth["ZToMuMu"]  = 0
+sampleLineWidth["ttbar"]    = 0
+sampleLineWidth["ST_tW"]    = 0
+sampleLineWidth["TTX"]      = 0
+sampleLineWidth["WW"]       = 0
+sampleLineWidth["ZZ"]       = 0
+sampleLineWidth["WZ"]       = 0
+
+sampleLegend=dict()
+sampleLegend["Y3"]       = "Y3"
+sampleLegend["data"]     = "data"
+sampleLegend["ZToMuMu"]  = "DY(#mu#mu)"
+sampleLegend["ttbar"]    = "t#bar{t}"
+sampleLegend["ST_tW"]    = "tW"
+sampleLegend["TTX"]      = "t#bar{t}X"
+sampleLegend["WW"]       = "WW"
+sampleLegend["ZZ"]       = "ZZ"
+sampleLegend["WZ"]       = "WZ"
+
+
+def get_files(samples):
+
+    sampleDict=OrderedDict()
+
+    for i,sample in enumerate(samples):
+        if sample=="Y3" or sample=="DY3" or sample=="DYp3" or sample=="B3mL2":
+            for mass in args.signalMass: 
+                 sampleDict[sample+"_M"+str(mass)]=ROOT.TFile(args.inDir+"output_"+sample+"_M"+str(mass)+"_2018.root")
+        elif sample=="ZToMuMu":
+            for m1,m2 in zip(["50","120","200","400","800","1400","2300","3500","4500","6000"],["120","200","400","800","1400","2300","3500","4500","6000","Inf"]): 
+                sampleDict[sample+"_"+m1+"_"+m2]=ROOT.TFile(args.inDir+"output_ZToMuMu_"+m1+"_"+m2+"_2018.root")
+        else:
+            sampleDict[sample]=ROOT.TFile(args.inDir+"output_"+sample+"_2018.root")
+
+    return sampleDict
+
+
+def get_plots(sampleDict, plotname):
+    plotDict=OrderedDict()
+
+    ZToMuMuPlot=None
+    ST_tWPlot=None
+    TTXPlot=None
+    for i,sample in enumerate(sampleDict.keys()):
+        inFile = sampleDict[sample]
+        if "ZToMuMu" in sample:
+            if not ZToMuMuPlot:
+                ZToMuMuPlot = copy.deepcopy(inFile.Get(plotname))
+            else:
+                ZToMuMuPlot.Add(inFile.Get(plotname))
+            plotDict["ZToMuMu"] = ZToMuMuPlot
+        elif sample=="tW" or sample=="tbarW":
+            if not ST_tWPlot:
+                ST_tWPlot = copy.deepcopy(inFile.Get(plotname))
+            else:
+                ST_tWPlot.Add(inFile.Get(plotname))
+            plotDict["ST_tW"] = ST_tWPlot
+        elif sample=="TTW" or sample=="TTZ" or sample=="TTHToNonbb" or sample=="TTHTobb":
+            if not TTXPlot:
+                TTXPlot = copy.deepcopy(inFile.Get(plotname))
+            else:
+                TTXPlot.Add(inFile.Get(plotname))
+            plotDict["TTX"] = TTXPlot
+        else:
+            plotDict[sample] = inFile.Get(plotname)
+
+    return plotDict
+
+
+def customize_plot(plot, fillColor, lineColor, lineWidth):
     plot.SetBinContent(1, plot.GetBinContent(1) + plot.GetBinContent(0))
     plot.SetBinContent(plot.GetNbinsX(), plot.GetBinContent(plot.GetNbinsX() + 1) + plot.GetBinContent(plot.GetNbinsX()))
 
@@ -90,7 +196,8 @@ def get_plot(plotFile, plotname, fillColor=None, lineColor=None, lineWidth=0):
 
     return plot
 
-def draw_plot(plotname="fatjet_msoftdrop", title="myTitle", log=True, plotData=False, doRatio=True, lumi=59.83, year="2018"):
+
+def draw_plot(sampleDict, plotname="fatjet_msoftdrop", title="myTitle", log=True, plotData=False, doRatio=True, lumi=59.83, year="2018"):
 
     #labels
     latex = ROOT.TLatex()
@@ -125,112 +232,70 @@ def draw_plot(plotname="fatjet_msoftdrop", title="myTitle", log=True, plotData=F
         yearenergy="%.0f fb^{-1} (13 TeV)"%(lumi)
     cmsExtra="Simulation"
 
-    #open file
-    signalfiles = []
-    ZToMuMufiles = []
-    for mass in args.signalMass: 
-        signalfiles.append(ROOT.TFile(args.inDir+"output_Y3_M"+str(mass)+"_2018.root"))
-    for m1,m2 in zip(["50","120","200","400","800","1400","2300","3500","4500","6000"],["120","200","400","800","1400","2300","3500","4500","6000","Inf"]): 
-        ZToMuMufiles.append(ROOT.TFile(args.inDir+"output_ZToMuMu_"+m1+"_"+m2+"_2018.root"))
-    ttbarfile =  ROOT.TFile(args.inDir+"output_ttbar_2018.root")
-    tWfile =     ROOT.TFile(args.inDir+"output_tW_2018.root")
-    tbarWfile =  ROOT.TFile(args.inDir+"output_tbarW_2018.root")
-    TTWfile =    ROOT.TFile(args.inDir+"output_TTW_2018.root")
-    TTZfile =    ROOT.TFile(args.inDir+"output_TTZ_2018.root")
-    TTHNobbfile= ROOT.TFile(args.inDir+"output_TTHToNonbb_2018.root")
-    TTHbbfile=   ROOT.TFile(args.inDir+"output_TTHTobb_2018.root")
-    WWfile =     ROOT.TFile(args.inDir+"output_WW_2018.root")
-    ZZfile =     ROOT.TFile(args.inDir+"output_ZZ_2018.root")
-    WZfile =     ROOT.TFile(args.inDir+"output_WZ_2018.root")
-    if plotData: 
-        datafile = ROOT.TFile(args.inDir+"data_2018_2_selected.root")
 
-    #get historam
-    signalplots = []
-    ZToMuMuplots = []
-    for i in range(len(args.signalMass)): 
-        signalplots.append(get_plot(signalfiles[i],plotname,lineColor=ROOT.kViolet-9+i,lineWidth=2))
-        if args.shape and signalplots[i].Integral(0,-1)>0.0:
-            if "cutflow" not in plotname:
-                signalplots[i].Scale(1.0/signalplots[i].Integral(0,-1))
+    #get histograms
+    plotDict = get_plots(sampleDict, plotname)
+    curPlots=OrderedDict()
+
+    totalSM = None
+    for i,sample in enumerate(plotDict.keys()):
+        # Signal
+        if "Y3" in sample or "DY3" in sample or "DYp3" in sample or "B3mL2" in sample:
+            model = sample.split("_")[0]
+            mass = sample.split("_")[1].lstrip("M")
+            curPlots[sample] = copy.deepcopy(customize_plot(plotDict[sample],sampleFillColor[model],sampleLineColor[model]+i%len(args.signalMass),sampleLineWidth[model]))
+            if args.shape and curPlots[sample].Integral(0,-1)>0.0:
+                if "cutflow" not in plotname:
+                    curPlots[sample].Scale(1.0/curPlots[sample].Integral(0,-1))
+                else:
+                    curPlots[sample].Scale(1.0/curPlots[sample].GetBinContent(1))
+        # Data
+        elif sample=="data": 
+            if plotData:
+                curPlots[sample] = copy.deepcopy(customize_plot(plotDict[sample],sampleFillColor[sample],sampleLineColor[sample],sampleLineWidth[sample]))
+        # Bkg
+        else:
+            curPlots[sample] = copy.deepcopy(customize_plot(plotDict[sample],sampleFillColor[sample],sampleLineColor[sample],sampleLineWidth[sample]))
+            if not totalSM:
+                totalSM = curPlots[sample].Clone("totalSM")
             else:
-                signalplots[i].Scale(1.0/signalplots[i].GetBinContent(1))
-    if plotData: 
-        dataplot = get_plot(datafile,plotname,lineColor=ROOT.kBlack,lineWidth=2)
-    for i in range(len(ZToMuMufiles)): 
-        ZToMuMuplots.append(get_plot(ZToMuMufiles[i],plotname,fillColor=ROOT.kGreen+1))
-    ttbarplot = get_plot(ttbarfile,plotname,fillColor=ROOT.kAzure+1)
-    tWplot = get_plot(tWfile,plotname,fillColor=ROOT.kAzure+2)
-    tbarWplot = get_plot(tbarWfile,plotname,fillColor=ROOT.kAzure+2)
-    TTWplot = get_plot(TTWfile,plotname,fillColor=ROOT.kAzure+4)
-    TTZplot = get_plot(TTZfile,plotname,fillColor=ROOT.kAzure+4)
-    TTHNobbplot = get_plot(TTHNobbfile,plotname,fillColor=ROOT.kAzure+4)
-    TTHbbplot = get_plot(TTHNobbfile,plotname,fillColor=ROOT.kAzure+4)
-    WWplot = get_plot(WWfile,plotname,fillColor=ROOT.kOrange-3)
-    ZZplot = get_plot(ZZfile,plotname,fillColor=ROOT.kOrange-2)
-    WZplot = get_plot(WZfile,plotname,fillColor=ROOT.kOrange-1)
+                totalSM.Add(curPlots[sample])
 
-    #add histos
-    ZToMuMuplot = ZToMuMuplots[0].Clone("ZToMuMu")
-    for i in range(1,len(ZToMuMuplots)): 
-        ZToMuMuplot.Add(ZToMuMuplots[i])
-    ST_tWplot = tWplot.Clone("ST_tW")
-    ST_tWplot.Add(tbarWplot)
-    TTXplot = TTWplot.Clone("TTX")
-    TTXplot.Add(TTZplot)
-    TTXplot.Add(TTHNobbplot)
-    TTXplot.Add(TTHbbplot)
-
-    totalSM = ZToMuMuplot.Clone("totalSM")
-    totalSM.Add(ttbarplot)
-    totalSM.Add(ST_tWplot)
-    totalSM.Add(TTXplot)
-    totalSM.Add(WWplot)
-    totalSM.Add(ZZplot)
-    totalSM.Add(WZplot)
     totalScale   = totalSM.Integral(0,-1)
     if "cutflow" in plotname:
         totalScale = totalSM.GetBinContent(1)
 
-    if args.shape and totalScale>0.0:
-        ZToMuMuplot.Scale(1.0/totalScale)
-        ttbarplot.Scale(1.0/totalScale)
-        ST_tWplot.Scale(1.0/totalScale)
-        TTXplot.Scale(1.0/totalScale)
-        WWplot.Scale(1.0/totalScale)
-        ZZplot.Scale(1.0/totalScale)
-        WZplot.Scale(1.0/totalScale)
+    #build stack
+    stack = ROOT.THStack("stack","")
+    for i,sample in enumerate(reversed(plotDict.keys())):
+        # Bkg
+        if not ("Y3" in sample or "DY3" in sample or "DYp3" in sample or "B3mL2" in sample or sample=="data"):
+            if args.shape and totalScale>0.0:
+                curPlots[sample].Scale(1.0/totalScale)
+            stack.Add(curPlots[sample])
+    stack.SetTitle(title)
 
     signalXSecScale = { }
     if log==False and args.signalScale and not args.shape:
-        for i,mass in enumerate(args.signalMass):
-            sigIntegral = signalplots[i].Integral(0,-1)
-            steps = [50.0, 100.0, 500.0, 1000.0, 5000.0, 10000.0, 50000.0]
-            signalXSecScale[str(mass)]=1.0
-            if sigIntegral>0.0 and totalScale>0.0:
-                ratioSMToSig = totalScale / sigIntegral
-                ratioSigToSM = sigIntegral / totalScale
-                for s in steps:
-                    if ratioSMToSig<s:
-                        signalXSecScale[str(mass)]=s/50.0
-                        if ratioSigToSM*(s/50.0) > 1:
+        for sample in curPlots.keys():
+            if "Y3" in sample or "DY3" in sample or "DYp3" in sample or "B3mL2" in sample:
+                mass = sample.split("_")[1].lstrip("M")
+                sigIntegral = curPlots[sample].Integral(0,-1)
+                steps = [50.0, 100.0, 500.0, 1000.0, 5000.0, 10000.0, 50000.0]
+                signalXSecScale[str(mass)]=1.0
+                if sigIntegral>0.0 and totalScale>0.0:
+                    ratioSMToSig = totalScale / sigIntegral
+                    ratioSigToSM = sigIntegral / totalScale
+                    for s in steps:
+                        if ratioSMToSig<s:
+                            signalXSecScale[str(mass)]=s/50.0
+                            if ratioSigToSM*(s/50.0) > 1:
+                                signalXSecScale[str(mass)]=signalXSecScale[str(mass)]/10.0
+                    if ratioSMToSig>steps[len(steps)-1]:
+                        signalXSecScale[str(mass)]=5e3
+                        if ratioSigToSM*(5e3) > 1:
                             signalXSecScale[str(mass)]=signalXSecScale[str(mass)]/10.0
-                if ratioSMToSig>steps[len(steps)-1]:
-                    signalXSecScale[str(mass)]=5e3
-                    if ratioSigToSM*(5e3) > 1:
-                        signalXSecScale[str(mass)]=signalXSecScale[str(mass)]/10.0
-            signalplots[i].Scale(signalXSecScale[str(mass)])
-
-    #build stack
-    stack = ROOT.THStack("stack","")
-    stack.Add(WZplot)
-    stack.Add(ZZplot)
-    stack.Add(WWplot)
-    stack.Add(TTXplot)
-    stack.Add(ST_tWplot)
-    stack.Add(ttbarplot)
-    stack.Add(ZToMuMuplot)
-    stack.SetTitle(title)
+                curPlots[sample].Scale(signalXSecScale[str(mass)])
 
     #plot legends, ranges
     legend = ROOT.TLegend(0.65,0.65,0.89,0.89)
@@ -243,85 +308,65 @@ def draw_plot(plotname="fatjet_msoftdrop", title="myTitle", log=True, plotData=F
     #legend.SetTextSize(0.02)
 
     if args.extendedLegend:
-        for i,mass in enumerate(args.signalMass): 
-            if log==False and args.signalScale and not args.shape and signalXSecScale[str(mass)]>1.5:
-                if "cutflow" not in plotname:
-                    legend.AddEntry(signalplots[i],"Y3 ("+str(mass)+" GeV) %1.2E (x%1.1E)"%(signalplots[i].Integral(0,-1),float(signalXSecScale[str(mass)])),"L")
+        for sample in curPlots.keys():
+            # Signal
+            if "Y3" in sample or "DY3" in sample or "DYp3" in sample or "B3mL2" in sample:
+                model = sample.split("_")[0]
+                mass = sample.split("_")[1].lstrip("M")
+                if log==False and args.signalScale and not args.shape and signalXSecScale[str(mass)]>1.5:
+                    if "cutflow" not in plotname:
+                        legend.AddEntry(curPlots[sample],sampleLegend[model]+" ("+str(mass)+" GeV) %1.2E (x%1.1E)"%(curPlots[sample].Integral(0,-1),float(signalXSecScale[str(mass)])),"L")
+                    else:
+                        legend.AddEntry(curPlots[sample],sampleLegend[model]+" ("+str(mass)+" GeV) %1.2E (x%1.1E)"%(curPlots[sample].GetBinContent(1),float(signalXSecScale[str(mass)])),"L")
                 else:
-                    legend.AddEntry(signalplots[i],"Y3 ("+str(mass)+" GeV) %1.2E (x%1.1E)"%(signalplots[i].GetBinContent(1),float(signalXSecScale[str(mass)])),"L")
+                    if "cutflow" not in plotname:
+                        legend.AddEntry(curPlots[sample],sampleLegend[model]+" ("+str(mass)+" GeV) %1.2E"%(curPlots[sample].Integral(0,-1)),"L")
+                    else:
+                        legend.AddEntry(curPlots[sample],sampleLegend[model]+" ("+str(mass)+" GeV) %1.2E"%(curPlots[sample].GetBinContent(1)),"L")
+            # Data
+            elif sample=="data": 
+                if plotData:
+                    if "cutflow" not in plotname:
+                        legend.AddEntry(curPlots[sample],sampleLegend[sample]+" %1.2E"%(curPlots[sample].Integral(0,-1)),"PL")
+                    else:
+                        legend.AddEntry(curPlots[sample],sampleLegend[sample]+" %1.2E"%(curPlots[sample].GetBinContent(1)),"PL")
+            # Bkg 
             else:
                 if "cutflow" not in plotname:
-                    legend.AddEntry(signalplots[i],"Y3 ("+str(mass)+" GeV) %1.2E"%(signalplots[i].Integral(0,-1)),"L")
+                    legend.AddEntry(curPlots[sample], sampleLegend[sample]+" %1.2E"%(curPlots[sample].Integral(0,-1)),"F")
                 else:
-                    legend.AddEntry(signalplots[i],"Y3 ("+str(mass)+" GeV) %1.2E"%(signalplots[i].GetBinContent(1)),"L")
-            
-        if "cutflow" not in plotname:
-            if plotData: 
-                legend.AddEntry(dataplot,"data %1.2E"%(dataplot.Integral(0,-1)),"PL")
-            legend.AddEntry(ZToMuMuplot, "DY(#mu#mu) %1.2E"%(ZToMuMuplot.Integral(0,-1)),"F")
-            legend.AddEntry(ttbarplot,"t#bar{t} %1.2E"%(ttbarplot.Integral(0,-1)),"F")
-            legend.AddEntry(ST_tWplot,"tW %1.2E"%(ST_tWplot.Integral(0,-1)),"F")
-            legend.AddEntry(TTXplot,"t#bar{t}X %1.2E"%(TTXplot.Integral(0,-1)),"F")
-            legend.AddEntry(WWplot,"WW %1.2E"%(WWplot.Integral(0,-1)),"F")
-            legend.AddEntry(ZZplot,"ZZ %1.2E"%(ZZplot.Integral(0,-1)),"F")
-            legend.AddEntry(WZplot,"WZ %1.2E"%(WZplot.Integral(0,-1)),"F")
-        else:
-            if plotData: 
-                legend.AddEntry(dataplot,"data %1.2E"%(dataplot.GetBinContent(1)),"PL")
-            legend.AddEntry(ZToMuMuplot, "DY(#mu#mu) %1.2E"%(ZToMuMuplot.GetBinContent(1)),"F")
-            legend.AddEntry(ttbarplot,"t#bar{t} %1.2E"%(ttbarplot.GetBinContent(1)),"F")
-            legend.AddEntry(TTXplot,"t#bar{t}X %1.2E"%(TTXplot.GetBinContent(1)),"F")
-            legend.AddEntry(ST_tWplot,"tW %1.2E"%(ST_tWplot.GetBinContent(1)),"F")
-            legend.AddEntry(WWplot,"WW %1.2E"%(WWplot.GetBinContent(1)),"F")
-            legend.AddEntry(ZZplot,"ZZ %1.2E"%(ZZplot.GetBinContent(1)),"F")
-            legend.AddEntry(WZplot,"WZ %1.2E"%(WZplot.GetBinContent(1)),"F")
+                    legend.AddEntry(curPlots[sample], sampleLegend[sample]+" %1.2E"%(curPlots[sample].GetBinContent(1)),"F")
     
     else:
-        for i,mass in enumerate(args.signalMass): 
-            if log==False and args.signalScale and not args.shape and signalXSecScale[str(mass)]>1.5:
-                if "cutflow" not in plotname:
-                    legend.AddEntry(signalplots[i],"Y3 ("+str(mass)+" GeV) x%1.1E"%(float(signalXSecScale[str(mass)])),"L")
+        for sample in curPlots.keys():
+            # Signal
+            if "Y3" in sample or "DY3" in sample or "DYp3" in sample or "B3mL2" in sample:
+                model = sample.split("_")[0]
+                mass = sample.split("_")[1].lstrip("M")
+                if log==False and args.signalScale and not args.shape and signalXSecScale[str(mass)]>1.5:
+                    if "cutflow" not in plotname:
+                        legend.AddEntry(curPlots[sample],sampleLegend[model]+" ("+str(mass)+" GeV) x%1.1E"%(float(signalXSecScale[str(mass)])),"L")
+                    else:
+                        legend.AddEntry(curPlots[sample],sampleLegend[model]+" ("+str(mass)+" GeV) x%1.1E"%(float(signalXSecScale[str(mass)])),"L")
                 else:
-                    legend.AddEntry(signalplots[i],"Y3 ("+str(mass)+" GeV) x%1.1E"%(float(signalXSecScale[str(mass)])),"L")
+                    if "cutflow" not in plotname:
+                        legend.AddEntry(curPlots[sample],sampleLegend[model]+" ("+str(mass)+" GeV)","L")
+                    else:
+                        legend.AddEntry(curPlots[sample],sampleLegend[model]+" ("+str(mass)+" GeV)","L")
+            # Data
+            elif sample=="data": 
+                if plotData:
+                    legend.AddEntry(curPlots[sample],sampleLegend[sample],"PL")
+            # Bkg
             else:
-                if "cutflow" not in plotname:
-                    legend.AddEntry(signalplots[i],"Y3 ("+str(mass)+" GeV)","L")
-                else:
-                    legend.AddEntry(signalplots[i],"Y3 ("+str(mass)+" GeV)","L")
-            
-        if "cutflow" not in plotname:
-            if plotData: 
-                legend.AddEntry(dataplot,"data","PL")
-            legend.AddEntry(ZToMuMuplot, "DY(#mu#mu)","F")
-            legend.AddEntry(ttbarplot,"t#bar{t}","F")
-            legend.AddEntry(ST_tWplot,"tW","F")
-            legend.AddEntry(TTXplot,"t#bar{t}X","F")
-            legend.AddEntry(WWplot,"WW","F")
-            legend.AddEntry(ZZplot,"ZZ","F")
-            legend.AddEntry(WZplot,"WZ","F")
-        else:
-            if plotData: 
-                legend.AddEntry(dataplot,"data","PL")
-            legend.AddEntry(ZToMuMuplot, "DY(#mu#mu)","F")
-            legend.AddEntry(ttbarplot,"t#bar{t}","F")
-            legend.AddEntry(TTXplot,"t#bar{t}X","F")
-            legend.AddEntry(ST_tWplot,"tW","F")
-            legend.AddEntry(WWplot,"WW","F")
-            legend.AddEntry(ZZplot,"ZZ","F")
-            legend.AddEntry(WZplot,"WZ","F")
+                legend.AddEntry(curPlots[sample], sampleLegend[sample],"F")
     
     #define canvas
     canvas = ROOT.TCanvas("canvas","canvas",800,800)
 
     if doRatio==True:
-        MCplot = copy.deepcopy(ZToMuMuplot)
-        MCplot.Add(ttbarplot)
-        MCplot.Add(ST_tWplot)
-        MCplot.Add(WWplot)
-        MCplot.Add(TTXplot)
-        MCplot.Add(ZZplot)
-        MCplot.Add(WZplot)
-        ratioplot=copy.deepcopy(dataplot)
+        MCplot = copy.deepcopy(totalSM)
+        ratioplot=copy.deepcopy(curPlots["data"])
         ratioplot.Divide(MCplot)
         ratioplot.SetTitle(";"+title+";Data / MC")
         pad1 = ROOT.TPad("pad1","pad1",0,0.3,1,1)
@@ -351,12 +396,13 @@ def draw_plot(plotname="fatjet_msoftdrop", title="myTitle", log=True, plotData=F
     stack.GetYaxis().SetLabelSize(0.03)
     stack.GetYaxis().SetMaxDigits(3)
     histMax = 0.0
-    for i,mass in enumerate(args.signalMass):
-        if histMax < signalplots[i].GetMaximum(): 
-            histMax = signalplots[i].GetMaximum()
-        signalplots[i].Draw("HIST same")
+    for sample in curPlots.keys():
+        if "Y3" in sample or "DY3" in sample or "DYp3" in sample or "B3mL2" in sample:
+            if histMax < curPlots[sample].GetMaximum(): 
+                histMax = curPlots[sample].GetMaximum()
+            curPlots[sample].Draw("HIST same")
     if plotData: 
-        dataplot.Draw("E0 same")
+        curPlots["data"].Draw("E0 same")
 
     if histMax < stack.GetMaximum(): 
         histMax = stack.GetMaximum()
@@ -411,105 +457,110 @@ def draw_plot(plotname="fatjet_msoftdrop", title="myTitle", log=True, plotData=F
     
     canvas.SaveAs(args.outDir + plotname + extension + ".png")
 
-    if("pt" in plotname or "mll_pf" in plotname):
-        canvas.Clear()
-        canvas.cd()
-        
-        if doRatio==True:
-            if ratioplot.GetXaxis().GetBinLowEdge(1)<=0.0:
-                ratioplot.GetXaxis().SetRangeUser(1.0, ratioplot.GetXaxis().GetBinUpEdge(ratioplot.GetNbinsX()))
-            ratioplot.SetTitle(";"+title+";Data / MC")
-            pad1 = ROOT.TPad("pad1","pad1",0,0.3,1,1)
-            pad2 = ROOT.TPad("pad2","pad2",0,0,1,0.3)
-            pad1.Draw()
-            pad2.Draw()
-            pad2.cd()
-            pad2.SetLogx()
-            ratioplot.Draw("E0")
+    #if("pt" in plotname or "mll_pf" in plotname):
+    #    canvas.Clear()
+    #    canvas.cd()
+    #    
+    #    if doRatio==True:
+    #        if ratioplot.GetXaxis().GetBinLowEdge(1)<=0.0:
+    #            ratioplot.GetXaxis().SetRangeUser(1.0, ratioplot.GetXaxis().GetBinUpEdge(ratioplot.GetNbinsX()))
+    #        ratioplot.SetTitle(";"+title+";Data / MC")
+    #        pad1 = ROOT.TPad("pad1","pad1",0,0.3,1,1)
+    #        pad2 = ROOT.TPad("pad2","pad2",0,0,1,0.3)
+    #        pad1.Draw()
+    #        pad2.Draw()
+    #        pad2.cd()
+    #        pad2.SetLogx()
+    #        ratioplot.Draw("E0")
 
-        if doRatio==False:
-            pad1 = ROOT.TPad("pad1","pad1",0,0,1,1)
-            pad1.Draw()
-            
-        pad1.cd()
-        if log==True:
-            pad1.SetLogy()
-        pad1.SetLogx()
-        
-        #plot data,stack, signal, data  
-        stack.Draw("HIST")
-        if stack.GetXaxis().GetBinLowEdge(1)<=0.0:
-            stack.GetXaxis().SetRangeUser(1.0, stack.GetXaxis().GetBinUpEdge(stack.GetXaxis().GetNbins()))
-        stack.GetXaxis().SetTitle(totalSM.GetXaxis().GetTitle())
-        stack.GetYaxis().SetTitle(totalSM.GetYaxis().GetTitle())
-        if args.shape:
-            stack.GetYaxis().SetTitle("A.U.")
-        stack.GetYaxis().SetLabelSize(0.03)
-        stack.GetYaxis().SetMaxDigits(3)
-        histMax = 0.0
-        for i,mass in enumerate(args.signalMass):
-            if histMax < signalplots[i].GetMaximum(): 
-                histMax = signalplots[i].GetMaximum()
-            signalplots[i].Draw("HIST same")
-        if plotData: 
-            dataplot.Draw("E0 same")
+    #    if doRatio==False:
+    #        pad1 = ROOT.TPad("pad1","pad1",0,0,1,1)
+    #        pad1.Draw()
+    #        
+    #    pad1.cd()
+    #    if log==True:
+    #        pad1.SetLogy()
+    #    pad1.SetLogx()
+    #    
+    #    #plot data,stack, signal, data  
+    #    stack.Draw("HIST")
+    #    if stack.GetXaxis().GetBinLowEdge(1)<=0.0:
+    #        stack.GetXaxis().SetRangeUser(1.0, stack.GetXaxis().GetBinUpEdge(stack.GetXaxis().GetNbins()))
+    #    stack.GetXaxis().SetTitle(totalSM.GetXaxis().GetTitle())
+    #    stack.GetYaxis().SetTitle(totalSM.GetYaxis().GetTitle())
+    #    if args.shape:
+    #        stack.GetYaxis().SetTitle("A.U.")
+    #    stack.GetYaxis().SetLabelSize(0.03)
+    #    stack.GetYaxis().SetMaxDigits(3)
+    #    histMax = 0.0
+    #    for sample in curPlots.keys():
+    #        if "Y3" in sample or "DY3" in sample or "DYp3" in sample or "B3mL2" in sample:
+    #            if histMax < curPlots[sample].GetMaximum(): 
+    #                histMax = curPlots[sample].GetMaximum()
+    #            curPlots[sample].Draw("HIST same")
+    #    if plotData: 
+    #        dataplot.Draw("E0 same")
 
-        if histMax < stack.GetMaximum(): 
-            histMax = stack.GetMaximum()
-        if log==True:
-            histMax = histMax*1e3
-            stack.SetMinimum(1e-3)
-        
-        stack.SetMaximum(1.1*histMax)
+    #    if histMax < stack.GetMaximum(): 
+    #        histMax = stack.GetMaximum()
+    #    if log==True:
+    #        histMax = histMax*1e3
+    #        stack.SetMinimum(1e-3)
+    #    
+    #    stack.SetMaximum(1.1*histMax)
 
-        canvas.Update()
+    #    canvas.Update()
 
-        legend.Draw()
-        
-        ROOT.gPad.RedrawAxis()
-        
-        latex.DrawLatex(0.9, 0.92+0.03, yearenergy);
-        latexCMS.DrawLatex(0.11,0.92+0.03,"CMS");
-        latexCMSExtra.DrawLatex(0.22,0.92+0.03, cmsExtra);
-        
-        whichnb  = plotname.split("_")[len(plotname.split("_"))-1]
-        whichmll = plotname.split("_")[len(plotname.split("_"))-2]
-        whichsel = plotname.split("_")[len(plotname.split("_"))-3]
-        ts = 0
-        for s in range(0,nsel[whichsel]+1):
-            if '1p' not in whichnb and s==7:
-                continue
-            if 'inclusive' not in whichmll and s==8:
-                continue
-                ts = ts+1
-            latexSel.DrawLatex(0.3+3*legoffset, 0.89-ts*(0.028-legoffset), sels[s])
-        if '1p' not in whichnb and nsel[whichsel]>=9:
-            ts = ts+1
-            latexSel.DrawLatex(0.3+3*legoffset, 0.89-ts*(0.028-legoffset), nbbin[whichnb])
-        if 'inclusive' not in whichmll and nsel[whichsel]>=7:
-            ts = ts+1
-            latexSel.DrawLatex(0.3+3*legoffset, 0.89-ts*(0.028-legoffset), mllbin[whichmll])
+    #    legend.Draw()
+    #    
+    #    ROOT.gPad.RedrawAxis()
+    #    
+    #    latex.DrawLatex(0.9, 0.92+0.03, yearenergy);
+    #    latexCMS.DrawLatex(0.11,0.92+0.03,"CMS");
+    #    latexCMSExtra.DrawLatex(0.22,0.92+0.03, cmsExtra);
+    #    
+    #    whichnb  = plotname.split("_")[len(plotname.split("_"))-1]
+    #    whichmll = plotname.split("_")[len(plotname.split("_"))-2]
+    #    whichsel = plotname.split("_")[len(plotname.split("_"))-3]
+    #    ts = 0
+    #    for s in range(0,nsel[whichsel]+1):
+    #        if '1p' not in whichnb and s==7:
+    #            continue
+    #        if 'inclusive' not in whichmll and s==8:
+    #            continue
+    #            ts = ts+1
+    #        latexSel.DrawLatex(0.3+3*legoffset, 0.89-ts*(0.028-legoffset), sels[s])
+    #    if '1p' not in whichnb and nsel[whichsel]>=9:
+    #        ts = ts+1
+    #        latexSel.DrawLatex(0.3+3*legoffset, 0.89-ts*(0.028-legoffset), nbbin[whichnb])
+    #    if 'inclusive' not in whichmll and nsel[whichsel]>=7:
+    #        ts = ts+1
+    #        latexSel.DrawLatex(0.3+3*legoffset, 0.89-ts*(0.028-legoffset), mllbin[whichmll])
 
-        #print and save
-        extension = ""
-        if plotData:
-            extension = extension+"_mc+data"
-        else:
-            extension = extension+"_s+b"
-        extension = extension+"_logX"
-        if log:
-            extension = extension+"_logY"
-        if args.shape:
-            extension = extension+"_areaNormalized"
-            
-        canvas.SaveAs(args.outDir + plotname + extension + ".png")
+    #    #print and save
+    #    extension = ""
+    #    if plotData:
+    #        extension = extension+"_mc+data"
+    #    else:
+    #        extension = extension+"_s+b"
+    #    extension = extension+"_logX"
+    #    if log:
+    #        extension = extension+"_logY"
+    #    if args.shape:
+    #        extension = extension+"_areaNormalized"
+    #        
+    #    canvas.SaveAs(args.outDir + plotname + extension + ".png")
 
 
+# Main
 ROOT.gStyle.SetOptStat(0)
 ROOT.gROOT.SetBatch(1)
 
+#open file
+sampleDict=get_files(samples)
+
 listofplots = []
-listfile = ROOT.TFile(args.inDir+"output_ttbar_2018.root")
+listfile = sampleDict[sampleDict.keys()[0]]
 listkeys = listfile.GetListOfKeys()
 size = listkeys.GetSize()
 for i in range(0,size):
@@ -520,5 +571,5 @@ for plot in listofplots:
     if plot in toexclude:
         continue
     title=""
-    draw_plot(plot, title, False, args.data, False, 59.83, "2018")
-    draw_plot(plot, title, True , args.data, False, 59.83, "2018")
+    draw_plot(sampleDict, plot, title, False, args.data, False, 59.83, "2018")
+    draw_plot(sampleDict, plot, title, True , args.data, False, 59.83, "2018")


### PR DESCRIPTION
This PR:
- Fixes a small bug in ttX.
- Attempts to streamline the plotting procedure by using dictionaries, defined at the beginning of the file, to control what's plotted and how. Adding a new sample (e.g. another signal sample) requires copying and slightly modifying only 5 lines at the beginning of the file.
- Loads the files only once, instead of loading them for each plot.

The logX plots cause the code to crash, which, I suspect, comes from a memory leak. I have commented out this part of the code for now and I will go back to it in a next commit. I am making this PR preemptively to gain feedback on the changes.