### PR TITLE
MET filters and reshuffling of selection

### DIFF
--- a/cpp/ScanChain_Zp.C
+++ b/cpp/ScanChain_Zp.C
@@ -653,8 +653,10 @@ int ScanChain(TChain *ch, double genEventSumw, TString year, TString process) {
 
       // Number of good primary vertices
       if ( nt.PV_npvsGood() < 1 ) continue;
+      // MET filters: https://twiki.cern.ch/twiki/bin/view/CMS/MissingETOptionalFiltersRun2#UL_data
+      if ( process.Contains("data") && !( nt.Flag_goodVertices()>=1 && nt.Flag_globalSuperTightHalo2016Filter()>=1 && nt.Flag_HBHENoiseFilter()>=1 && nt.Flag_HBHENoiseIsoFilter()>=1 && nt.Flag_EcalDeadCellTriggerPrimitiveFilter()>=1 && nt.Flag_BadPFMuonFilter()>=1 && nt.Flag_BadPFMuonDzFilter()>=1 && nt.Flag_eeBadScFilter()>=1 && ( year=="2016" ? 1 : nt.Flag_ecalBadCalibFilter()>=1 ) ) ) continue;
       // Fill histos: sel0
-      label = ">0 good PVs";
+      label = ">0 good PVs & MET Filters";
       slicedlabel = label;
       h_cutflow->Fill(icutflow,weight*factor);
       h_cutflow->GetXaxis()->SetBinLabel(icutflow+1,label);

--- a/cpp/ScanChain_Zp.C
+++ b/cpp/ScanChain_Zp.C
@@ -485,14 +485,14 @@ int ScanChain(TChain *ch, double genEventSumw, TString year, TString process) {
     for ( unsigned int iplot=0; iplot < plot_names.size(); iplot++ ) {
       if(isel<5) {
 	TString plot_name = plot_names[iplot];
-	TString name = plot_name+"_"+selection[isel]+"_"+mllbin[0]+"_"+nbtag[0];
+	TString name = plot_name+"_"+selection[isel]+"_"+mllbin[0];
 	HTemp(name,nbins[plot_name],low[plot_name],high[plot_name],title[plot_name]);
 	histos[name] = h_temp;
       }
       else if(isel>=5 && isel<7) {
 	for ( unsigned int imll=0; imll < mllbin.size(); imll++ ) {
 	  TString plot_name = plot_names[iplot];
-	  TString name = plot_name+"_"+selection[isel]+"_"+mllbin[imll]+"_"+nbtag[0];
+	  TString name = plot_name+"_"+selection[isel]+"_"+mllbin[imll];
 	  HTemp(name,nbins[plot_name],low[plot_name],high[plot_name],title[plot_name]);
 	  histos[name] = h_temp;
 	}
@@ -671,7 +671,7 @@ int ScanChain(TChain *ch, double genEventSumw, TString year, TString process) {
       TString sel = "sel0";
       for ( unsigned int iplot=0; iplot < plot_names.size(); iplot++ ) {
 	TString plot_name = plot_names[iplot];
-	TString name = plot_name+"_"+sel+"_"+mllbin[0]+"_"+nbtag[0];
+	TString name = plot_name+"_"+sel+"_"+mllbin[0];
 	histos[name]->Fill(variable[plot_name],weight*factor);
       }
 
@@ -721,7 +721,7 @@ int ScanChain(TChain *ch, double genEventSumw, TString year, TString process) {
       sel = "sel1";
       for ( unsigned int iplot=0; iplot < plot_names.size(); iplot++ ) {
 	TString plot_name = plot_names[iplot];
-	TString name = plot_name+"_"+sel+"_"+mllbin[0]+"_"+nbtag[0];
+	TString name = plot_name+"_"+sel+"_"+mllbin[0];
 	histos[name]->Fill(variable[plot_name],weight*factor);
       }
 
@@ -742,7 +742,7 @@ int ScanChain(TChain *ch, double genEventSumw, TString year, TString process) {
       sel = "sel2";
       for ( unsigned int iplot=0; iplot < plot_names.size(); iplot++ ) {
 	TString plot_name = plot_names[iplot];
-	TString name = plot_name+"_"+sel+"_"+mllbin[0]+"_"+nbtag[0];
+	TString name = plot_name+"_"+sel+"_"+mllbin[0];
 	histos[name]->Fill(variable[plot_name],weight*factor);
       }
 
@@ -763,7 +763,7 @@ int ScanChain(TChain *ch, double genEventSumw, TString year, TString process) {
       sel = "sel3";
       for ( unsigned int iplot=0; iplot < plot_names.size(); iplot++ ) {
 	TString plot_name = plot_names[iplot];
-	TString name = plot_name+"_"+sel+"_"+mllbin[0]+"_"+nbtag[0];
+	TString name = plot_name+"_"+sel+"_"+mllbin[0];
 	histos[name]->Fill(variable[plot_name],weight*factor);
       }
 
@@ -801,7 +801,7 @@ int ScanChain(TChain *ch, double genEventSumw, TString year, TString process) {
       sel = "sel4";
       for ( unsigned int iplot=0; iplot < plot_names.size(); iplot++ ) {
 	TString plot_name = plot_names[iplot];
-	TString name = plot_name+"_"+sel+"_"+mllbin[0]+"_"+nbtag[0];
+	TString name = plot_name+"_"+sel+"_"+mllbin[0];
 	histos[name]->Fill(variable[plot_name],weight*factor);
       }
 
@@ -1033,7 +1033,7 @@ int ScanChain(TChain *ch, double genEventSumw, TString year, TString process) {
       for ( unsigned int iplot=0; iplot < plot_names.size(); iplot++ ) {
 	TString plot_name = plot_names[iplot];
 	for ( unsigned int imll=0; imll < mllbin.size(); imll++ ) {
-	  TString name = plot_name+"_"+sel+"_"+mllbin[imll]+"_"+nbtag[0];
+	  TString name = plot_name+"_"+sel+"_"+mllbin[imll];
 	  if ( mllbinsel[imll] )
 	    histos[name]->Fill(variable[plot_name],weight*factor);
 	}
@@ -1042,7 +1042,7 @@ int ScanChain(TChain *ch, double genEventSumw, TString year, TString process) {
       for ( unsigned int iplot=0; iplot < extra_plot_names.size(); iplot++ ) {
 	TString plot_name = extra_plot_names[iplot];
 	for ( unsigned int imll=0; imll < mllbin.size(); imll++ ) {
-	  TString name = plot_name+"_"+sel+= "_"+mllbin[imll]+"_"+nbtag[0];
+	  TString name = plot_name+"_"+sel+= "_"+mllbin[imll];
 	  if ( mllbinsel[imll] )
 	    histos[name]->Fill(extra_variable[plot_name],weight*factor);
 	}
@@ -1083,7 +1083,7 @@ int ScanChain(TChain *ch, double genEventSumw, TString year, TString process) {
       for ( unsigned int iplot=0; iplot < plot_names.size(); iplot++ ) {
 	TString plot_name = plot_names[iplot];
 	for ( unsigned int imll=0; imll < mllbin.size(); imll++ ) {
-	  TString name = plot_name+"_"+sel+= "_"+mllbin[imll]+"_"+nbtag[0];
+	  TString name = plot_name+"_"+sel+= "_"+mllbin[imll];
 	  if ( mllbinsel[imll] )
 	    histos[name]->Fill(variable[plot_name],weight*factor);
 	}

--- a/cpp/ScanChain_Zp.C
+++ b/cpp/ScanChain_Zp.C
@@ -415,9 +415,9 @@ int ScanChain(TChain *ch, double genEventSumw, TString year, TString process) {
   selection.push_back("sel3"); // Relative track isolation < 0.1
   selection.push_back("sel4"); // Selected muon matched to HLT > 1 (DeltaR < 0.02)
   selection.push_back("sel5"); // At least one OS dimuon pair, not from Z
-  selection.push_back("sel6"); // No extra lepton / isoTrack
-  selection.push_back("sel7"); // NbTag >= 1 (medium WP)
-  selection.push_back("sel8"); // Mmumu > 150 GeV
+  selection.push_back("sel6"); // Mmumu > 150 GeV
+  selection.push_back("sel7"); // No extra lepton / isoTrack
+  selection.push_back("sel8"); // NbTag >= 1 (medium WP)
   selection.push_back("sel9"); // minMlb > 175 GeV
 
   vector<TString> plot_names = { };
@@ -439,7 +439,9 @@ int ScanChain(TChain *ch, double genEventSumw, TString year, TString process) {
       plot_names.push_back("mu1_trkRelIso");
       plot_names.push_back("mu2_trkRelIso");
       plot_names.push_back("nCand_Muons");
+    }
       // Add also extra plots before third lepton/isotrack veto
+    if (isel==6) {
       plot_names.push_back("nExtra_muons"); ++nExtraHistos;
       plot_names.push_back("nExtra_electrons"); ++nExtraHistos;
       plot_names.push_back("nExtra_lepIsoTracks"); ++nExtraHistos;
@@ -458,12 +460,12 @@ int ScanChain(TChain *ch, double genEventSumw, TString year, TString process) {
       plot_names.push_back("chhIsoTrack_extra_PFRelIsoChg"); ++nExtraHistos;
     }
     // Third lepton/isotrack veto
-    if (isel==6) {
+    if (isel==7) {
       // Remove plots added for thid lepton/isotrack veto
       for (int e=0; e<nExtraHistos; ++e)
 	plot_names.pop_back();
     }
-    if (isel==7) {
+    if (isel==8) {
       plot_names.push_back("nbtagDeepFlavB");
       plot_names.push_back("bjet1_pt");
       plot_names.push_back("bjet1_eta");
@@ -489,7 +491,7 @@ int ScanChain(TChain *ch, double genEventSumw, TString year, TString process) {
 	HTemp(name,nbins[plot_name],low[plot_name],high[plot_name],title[plot_name]);
 	histos[name] = h_temp;
       }
-      else if(isel>=5 && isel<7) {
+      else if(isel>=5 && isel<8) {
 	for ( unsigned int imll=0; imll < mllbin.size(); imll++ ) {
 	  TString plot_name = plot_names[iplot];
 	  TString name = plot_name+"_"+selection[isel]+"_"+mllbin[imll];
@@ -497,7 +499,7 @@ int ScanChain(TChain *ch, double genEventSumw, TString year, TString process) {
 	  histos[name] = h_temp;
 	}
       }
-      else if(isel>=7) {
+      else if(isel>=8) {
 	for ( unsigned int imll=0; imll < mllbin.size(); imll++ ) {
 	  for ( unsigned int inb=0; inb < nbtag.size(); inb++ ) {
 	    TString plot_name = plot_names[iplot];
@@ -895,6 +897,32 @@ int ScanChain(TChain *ch, double genEventSumw, TString year, TString process) {
 	}
       }
       icutflow++;
+      sel = "sel5";
+      for ( unsigned int iplot=0; iplot < plot_names.size(); iplot++ ) {
+        TString plot_name = plot_names[iplot];
+        for ( unsigned int imll=0; imll < mllbin.size(); imll++ ) {
+          TString name = plot_name+"_"+sel+"_"+mllbin[imll];
+          if ( mllbinsel[imll] )
+            histos[name]->Fill(variable[plot_name],weight*factor);
+        }
+      }
+
+      if ( selectedPair_M < 150 ) continue;
+      // Fill histos: sel6
+      label = "m(ll)>150 GeV";
+      slicedlabel = label;
+      h_cutflow->Fill(icutflow,weight*factor);
+      h_cutflow->GetXaxis()->SetBinLabel(icutflow+1,label);
+      for ( unsigned int imll=0; imll < mllbin.size(); imll++ ) {
+        for ( unsigned int inb=0; inb < nbtag.size(); inb++ ) {
+          TString slice = mllbin[imll]+"_"+nbtag[inb];
+          if ( mllbinsel[imll] )
+            slicedcutflows[slice]->Fill(icutflow,weight*factor);
+          slicedcutflows[slice]->GetXaxis()->SetBinLabel(icutflow+1,slicedlabel);
+        }
+      }
+      icutflow++;
+
       // Look for a third isolated lepton and then veto the event if it is found
       // Muons (using same ID and isolation as for selected muons, to avoid scale factor combinatorics)
       vector<int> extra_muons;
@@ -1028,8 +1056,8 @@ int ScanChain(TChain *ch, double genEventSumw, TString year, TString process) {
 	extra_variable.insert({"chhIsoTrack_extra_PFRelIsoChg", nt.IsoTrack_pfRelIso03_chg().at(extra_isotracks_chh[0])});
       }
 
-      // Fill standard histos for sel5
-      sel = "sel5";
+      // Fill standard histos for sel6
+      sel = "sel6";
       for ( unsigned int iplot=0; iplot < plot_names.size(); iplot++ ) {
 	TString plot_name = plot_names[iplot];
 	for ( unsigned int imll=0; imll < mllbin.size(); imll++ ) {
@@ -1038,7 +1066,7 @@ int ScanChain(TChain *ch, double genEventSumw, TString year, TString process) {
 	    histos[name]->Fill(variable[plot_name],weight*factor);
 	}
       }
-      // Now fill extra histos for sel5 (before third lepton/isotrack veto)
+      // Now fill extra histos for sel6 (before third lepton/isotrack veto)
       for ( unsigned int iplot=0; iplot < extra_plot_names.size(); iplot++ ) {
 	TString plot_name = extra_plot_names[iplot];
 	for ( unsigned int imll=0; imll < mllbin.size(); imll++ ) {
@@ -1078,8 +1106,8 @@ int ScanChain(TChain *ch, double genEventSumw, TString year, TString process) {
       }
       icutflow++;
 
-      // Fill histos: sel6
-      sel = "sel6";
+      // Fill histos: sel7
+      sel = "sel7";
       for ( unsigned int iplot=0; iplot < plot_names.size(); iplot++ ) {
 	TString plot_name = plot_names[iplot];
 	for ( unsigned int imll=0; imll < mllbin.size(); imll++ ) {
@@ -1159,7 +1187,7 @@ int ScanChain(TChain *ch, double genEventSumw, TString year, TString process) {
       }
       float dPhi_ll_MET = fabs(TVector2::Phi_mpi_pi(selectedPair_p4.Phi() - nt.MET_phi()));
 
-      // Add histos: sel7
+      // Add histos: sel8
       plot_names.push_back("nbtagDeepFlavB");
       variable.insert({"nbtagDeepFlavB", cand_bJets.size()});
 
@@ -1209,7 +1237,7 @@ int ScanChain(TChain *ch, double genEventSumw, TString year, TString process) {
 	else nbtagsel[2] = false;
       }
 
-      // Fill histos: sel7
+      // Fill histos: sel8
       label = ">0 b-tag (medium WP)";
       slicedlabel = "";
       h_cutflow->Fill(icutflow,weight*factor);
@@ -1224,7 +1252,7 @@ int ScanChain(TChain *ch, double genEventSumw, TString year, TString process) {
 	}
       }
       icutflow++;
-      sel = "sel7";
+      sel = "sel8";
       for ( unsigned int iplot=0; iplot < plot_names.size(); iplot++ ) {
 	TString plot_name = plot_names[iplot];
 	//if ( plot_name.Contains("bjet2") && cand_bJets.size() < 2 ) continue;
@@ -1237,35 +1265,6 @@ int ScanChain(TChain *ch, double genEventSumw, TString year, TString process) {
 	}
       }
 
-
-      if ( selectedPair_M < 150 ) continue;
-      // Fill histos: sel8
-      label = "m(ll)>150 GeV";
-      slicedlabel = label;
-      h_cutflow->Fill(icutflow,weight*factor);
-      h_cutflow->GetXaxis()->SetBinLabel(icutflow+1,label);
-      for ( unsigned int imll=0; imll < mllbin.size(); imll++ ) {
-	for ( unsigned int inb=0; inb < nbtag.size(); inb++ ) {
-	  TString slice = mllbin[imll]+"_"+nbtag[inb];
-	  if ( mllbinsel[imll] && nbtagsel[inb] )
-	    slicedcutflows[slice]->Fill(icutflow,weight*factor);
-	  slicedcutflows[slice]->GetXaxis()->SetBinLabel(icutflow+1,slicedlabel);
-	}
-      }
-      icutflow++;
-      sel = "sel8";
-      for ( unsigned int iplot=0; iplot < plot_names.size(); iplot++ ) {
-	TString plot_name = plot_names[iplot];
-	//if ( plot_name.Contains("bjet2") && cand_bJets.size() < 2 ) continue;
-	for ( unsigned int imll=0; imll < mllbin.size(); imll++ ) {
-	  for ( unsigned int inb=0; inb < nbtag.size(); inb++ ) {
-	    TString name = plot_name+"_"+sel+"_"+mllbin[imll]+"_"+nbtag[inb];
-	    if ( mllbinsel[imll] && nbtagsel[inb] ) 
-	      histos[name]->Fill(variable[plot_name],weight*factor);
-	  }
-	}
-      }
-      
       if ( min_mlb < 175.0 ) continue;
       label = "min m(lb)>175 GeV";
       slicedlabel = label;

--- a/cpp/doAll_Zp.C
+++ b/cpp/doAll_Zp.C
@@ -18,10 +18,10 @@
   samples.push_back("data");
   sample_names.insert({"data", "SingleMuon"});
   sample_prod.insert({"data", { { "2018",       {
-						 //"Run2018A-UL2018_MiniAODv2_NanoAODv9-v2",
-						 "Run2018B-UL2018_MiniAODv2_NanoAODv9-v2",
-						 //"Run2018C-UL2018_MiniAODv2_NanoAODv9-v2",
-						 //"Run2018D-UL2018_MiniAODv2_NanoAODv9-v1"
+						 //"Run2018A-UL2018_MiniAODv2_NanoAODv9_GT36-v1",
+						 "Run2018B-UL2018_MiniAODv2_NanoAODv9_GT36-v1",
+						 //"Run2018C-UL2018_MiniAODv2_NanoAODv9_GT36-v1",
+						 //"Run2018D-UL2018_MiniAODv2_NanoAODv9_GT36-v1"
 						} },
                                 { "2017",       {
 						 "Run2017B-UL2017_MiniAODv2_NanoAODv9-v1",

--- a/python/stack_plots.py
+++ b/python/stack_plots.py
@@ -55,9 +55,9 @@ sels.append("p_{T}^{#mu_{1,2}}>53 GeV & |#eta^{#mu_{1,2}}|<2.4")
 sels.append("Track iso./p_{T} (#mu_{1,2})<0.1")
 sels.append("N_{HLT match}#geq 1 (#DeltaR<0.02)")
 sels.append("N_{#mu#mu}#geq 1 (OS, not from Z)")
+sels.append("m_{#mu#mu}>150 GeV")
 sels.append("No extra lepton / iso. track")
 sels.append("N_{b-tag}#geq 1 (p_{T}>20 GeV, medium WP)")
-sels.append("m_{#mu#mu}>150 GeV")
 sels.append("min m_{#mu b}>175 GeV")
 
 nsel=dict()
@@ -261,17 +261,17 @@ def draw_plot(sampleDict, plotname, logY=True, logX=False, plotData=False, doRat
     latex = ROOT.TLatex()
     latex.SetTextFont(42)
     latex.SetTextAlign(31)
-    latex.SetTextSize(0.05)
+    latex.SetTextSize(0.04)
     latex.SetNDC(True)
 
     latexCMS = ROOT.TLatex()
     latexCMS.SetTextFont(61)
-    latexCMS.SetTextSize(0.06)
+    latexCMS.SetTextSize(0.05)
     latexCMS.SetNDC(True)
 
     latexCMSExtra = ROOT.TLatex()
     latexCMSExtra.SetTextFont(52)
-    latexCMSExtra.SetTextSize(0.05)
+    latexCMSExtra.SetTextSize(0.04)
     latexCMSExtra.SetNDC(True)
 
     legoffset = 0.0
@@ -298,10 +298,18 @@ def draw_plot(sampleDict, plotname, logY=True, logX=False, plotData=False, doRat
         cmsExtra="Simulation"
 
     if "cutflow" not in plotname:
-        thissel = plotname.split("_")[len(plotname.split("_"))-3]
+        thissel=""
+        if "sel8" in plotname or "sel9" in plotname:
+            thissel = plotname.split("_")[len(plotname.split("_"))-3]
+        else:
+            thissel = plotname.split("_")[len(plotname.split("_"))-2]
         if thissel not in args.selections:
             return(0)
-        thismll = plotname.split("_")[len(plotname.split("_"))-2]
+        thismll=""
+        if "sel8" in plotname or "sel9" in plotname:
+            thismll = plotname.split("_")[len(plotname.split("_"))-2]
+        else:
+            thismll = plotname.split("_")[len(plotname.split("_"))-1]
         if args.onlyInclusiveMll and 'inclusive' not in thismll:
             return(0)
         
@@ -382,9 +390,9 @@ def draw_plot(sampleDict, plotname, logY=True, logX=False, plotData=False, doRat
 
 
     # Plot legends, ranges
-    legend = ROOT.TLegend(0.7,0.6,0.91,0.91)
+    legend = ROOT.TLegend(0.7,0.6,0.89,0.89)
     if args.extendedLegend:
-        legend = ROOT.TLegend(0.6,0.6,0.91,0.91)
+        legend = ROOT.TLegend(0.6,0.6,0.89,0.89)
     legend.SetLineColor(0)
     legend.SetLineWidth(0)
     legend.SetFillColor(0)
@@ -600,16 +608,23 @@ def draw_plot(sampleDict, plotname, logY=True, logX=False, plotData=False, doRat
     expoffset=0.03
     if logY or 1.1*histMax<1000.0:
         expoffset=0
-    latex.DrawLatex(0.95, 0.95+expoffset, yearenergy);
-    latexCMS.DrawLatex(0.11,0.95+expoffset,"CMS");
-    latexCMSExtra.DrawLatex(0.22,0.95+expoffset, cmsExtra);
+    latex.DrawLatex(0.90, 0.91+expoffset, yearenergy);
+    latexCMS.DrawLatex(0.11,0.91+expoffset,"CMS");
+    latexCMSExtra.DrawLatex(0.22,0.91+expoffset, cmsExtra);
 
 
     # Draw selection
     if "cutflow" not in plotname:
-        whichnb  = plotname.split("_")[len(plotname.split("_"))-1]
-        whichmll = plotname.split("_")[len(plotname.split("_"))-2]
-        whichsel = plotname.split("_")[len(plotname.split("_"))-3]
+        whichnb  = ""
+        whichmll = ""
+        whichsel = ""
+        if "sel8" in plotname or "sel9" in plotname:
+            whichnb  = plotname.split("_")[len(plotname.split("_"))-1]
+            whichmll = plotname.split("_")[len(plotname.split("_"))-2]
+            whichsel = plotname.split("_")[len(plotname.split("_"))-3]
+        else:
+            whichmll = plotname.split("_")[len(plotname.split("_"))-1]
+            whichsel = plotname.split("_")[len(plotname.split("_"))-2]
         ts = 0
         for s in range(0,nsel[whichsel]+1):
             if '1p' not in whichnb and s==7:
@@ -617,13 +632,13 @@ def draw_plot(sampleDict, plotname, logY=True, logX=False, plotData=False, doRat
             if 'inclusive' not in whichmll and s==8:
                 continue
             ts = ts+1
-            latexSel.DrawLatex(0.45+3*legoffset, 0.91-ts*(0.03-legoffset), sels[s])
-        if '1p' not in whichnb and nsel[whichsel]>=9:
+            latexSel.DrawLatex(0.40+3*legoffset, 0.89-ts*(0.03-legoffset), sels[s])
+        if '1p' not in whichnb and nsel[whichsel]>=10:
             ts = ts+1
-            latexSel.DrawLatex(0.45+3*legoffset, 0.91-ts*(0.03-legoffset), nbbin[whichnb])
+            latexSel.DrawLatex(0.40+3*legoffset, 0.89-ts*(0.03-legoffset), nbbin[whichnb])
         if 'inclusive' not in whichmll and nsel[whichsel]>=7:
             ts = ts+1
-            latexSel.DrawLatex(0.45+3*legoffset, 0.91-ts*(0.03-legoffset), mllbin[whichmll])
+            latexSel.DrawLatex(0.40+3*legoffset, 0.89-ts*(0.03-legoffset), mllbin[whichmll])
 
 
     # Print and save

--- a/python/stack_plots.py
+++ b/python/stack_plots.py
@@ -49,7 +49,7 @@ if args.data:
 sels = []
 sels.append("N_{#mu}#geq 2, p_{T}^{#mu_{1}}>50 GeV, m_{#mu#mu}>100 GeV")
 sels.append("HLT selection")
-sels.append("N_{good PV}#geq 1")
+sels.append("N_{good PV}#geq 1 & MET filters")
 sels.append("N_{highPt ID #mu}#geq 2")
 sels.append("p_{T}^{#mu_{1,2}}>53 GeV & |#eta^{#mu_{1,2}}|<2.4")
 sels.append("Track iso./p_{T} (#mu_{1,2})<0.1")

--- a/python/stack_plots.py
+++ b/python/stack_plots.py
@@ -624,9 +624,9 @@ def draw_plot(sampleDict, plotname, logY=True, logX=False, plotData=False, doRat
     if logY or 1.1*histMax<1000.0:
         expoffset=0
     if args.data:
-        latex.DrawLatex(0.95, 0.93+expoffset, yearenergy);
-        latexCMS.DrawLatex(0.11,0.93+expoffset,"CMS");
-        latexCMSExtra.DrawLatex(0.22,0.93+expoffset, cmsExtra);
+        latex.DrawLatex(0.95, 0.94+expoffset, yearenergy);
+        latexCMS.DrawLatex(0.11,0.94+expoffset,"CMS");
+        latexCMSExtra.DrawLatex(0.22,0.94+expoffset, cmsExtra);
     else:
         latex.DrawLatex(0.90, 0.91+expoffset, yearenergy);
         latexCMS.DrawLatex(0.11,0.91+expoffset,"CMS");

--- a/python/stack_plots.py
+++ b/python/stack_plots.py
@@ -261,17 +261,26 @@ def draw_plot(sampleDict, plotname, logY=True, logX=False, plotData=False, doRat
     latex = ROOT.TLatex()
     latex.SetTextFont(42)
     latex.SetTextAlign(31)
-    latex.SetTextSize(0.04)
+    if args.data:
+        latex.SetTextSize(0.05)
+    else:
+        latex.SetTextSize(0.04)
     latex.SetNDC(True)
 
     latexCMS = ROOT.TLatex()
     latexCMS.SetTextFont(61)
-    latexCMS.SetTextSize(0.05)
+    if args.data:
+        latexCMS.SetTextSize(0.06)
+    else:
+        latexCMS.SetTextSize(0.05)
     latexCMS.SetNDC(True)
 
     latexCMSExtra = ROOT.TLatex()
     latexCMSExtra.SetTextFont(52)
-    latexCMSExtra.SetTextSize(0.04)
+    if args.data:
+        latexCMSExtra.SetTextSize(0.05)
+    else:
+        latexCMSExtra.SetTextSize(0.04)
     latexCMSExtra.SetNDC(True)
 
     legoffset = 0.0
@@ -390,9 +399,15 @@ def draw_plot(sampleDict, plotname, logY=True, logX=False, plotData=False, doRat
 
 
     # Plot legends, ranges
-    legend = ROOT.TLegend(0.7,0.6,0.89,0.89)
+    if args.data:
+        legend = ROOT.TLegend(0.7,0.6,0.91,0.91)
+    else:
+        legend = ROOT.TLegend(0.7,0.6,0.89,0.89)
     if args.extendedLegend:
-        legend = ROOT.TLegend(0.6,0.6,0.89,0.89)
+        if args.data:
+            legend = ROOT.TLegend(0.6,0.6,0.91,0.91)
+        else:
+            legend = ROOT.TLegend(0.7,0.6,0.89,0.89)
     legend.SetLineColor(0)
     legend.SetLineWidth(0)
     legend.SetFillColor(0)
@@ -608,9 +623,14 @@ def draw_plot(sampleDict, plotname, logY=True, logX=False, plotData=False, doRat
     expoffset=0.03
     if logY or 1.1*histMax<1000.0:
         expoffset=0
-    latex.DrawLatex(0.90, 0.91+expoffset, yearenergy);
-    latexCMS.DrawLatex(0.11,0.91+expoffset,"CMS");
-    latexCMSExtra.DrawLatex(0.22,0.91+expoffset, cmsExtra);
+    if args.data:
+        latex.DrawLatex(0.95, 0.93+expoffset, yearenergy);
+        latexCMS.DrawLatex(0.11,0.93+expoffset,"CMS");
+        latexCMSExtra.DrawLatex(0.22,0.93+expoffset, cmsExtra);
+    else:
+        latex.DrawLatex(0.90, 0.91+expoffset, yearenergy);
+        latexCMS.DrawLatex(0.11,0.91+expoffset,"CMS");
+        latexCMSExtra.DrawLatex(0.22,0.91+expoffset, cmsExtra);
 
 
     # Draw selection
@@ -632,13 +652,22 @@ def draw_plot(sampleDict, plotname, logY=True, logX=False, plotData=False, doRat
             if 'inclusive' not in whichmll and s==8:
                 continue
             ts = ts+1
-            latexSel.DrawLatex(0.40+3*legoffset, 0.89-ts*(0.03-legoffset), sels[s])
+            if args.data:
+                latexSel.DrawLatex(0.45+3*legoffset, 0.91-ts*(0.03-legoffset), sels[s])
+            else:
+                latexSel.DrawLatex(0.40+3*legoffset, 0.89-ts*(0.03-legoffset), sels[s])
         if '1p' not in whichnb and nsel[whichsel]>=10:
             ts = ts+1
-            latexSel.DrawLatex(0.40+3*legoffset, 0.89-ts*(0.03-legoffset), nbbin[whichnb])
+            if args.data:
+                latexSel.DrawLatex(0.45+3*legoffset, 0.91-ts*(0.03-legoffset), nbbin[whichnb])
+            else:
+                latexSel.DrawLatex(0.40+3*legoffset, 0.89-ts*(0.03-legoffset), nbbin[whichnb])
         if 'inclusive' not in whichmll and nsel[whichsel]>=7:
             ts = ts+1
-            latexSel.DrawLatex(0.40+3*legoffset, 0.89-ts*(0.03-legoffset), mllbin[whichmll])
+            if args.data:
+                latexSel.DrawLatex(0.45+3*legoffset, 0.91-ts*(0.03-legoffset), mllbin[whichmll])
+            else:
+                latexSel.DrawLatex(0.40+3*legoffset, 0.89-ts*(0.03-legoffset), mllbin[whichmll])
 
 
     # Print and save


### PR DESCRIPTION
In this PR:

- The MET filters are applied on data.
- The b-tag selection is removed from the titles of plots for which the b-tag selection has not yet been applied.
- The mll cut is moved after the OS pair selection.
- The reprocessed 2018 data samples are included.