### PR TITLE
Implementation of L1 pre-firing weight (for all years) and HEM15/16 veto (for 2018)

### DIFF
--- a/cpp/ScanChain_Zp.C
+++ b/cpp/ScanChain_Zp.C
@@ -1566,7 +1566,7 @@ int ScanChain(TChain *ch, double genEventSumw, TString year, TString process) {
         if ( dPhi_llb_MET < minDPhi_llb_MET ) minDPhi_llb_MET = dPhi_llb_MET;
 
         float dPhi_l_b = fabs(TVector2::Phi_mpi_pi(leadingMu_p4.Phi() - bjet_p4.Phi()));
-        if ( dPhi_l_b < minDPhi_lb ) minDPhi_l_b = dPhi_l_b;
+        if ( dPhi_l_b < minDPhi_l_b ) minDPhi_l_b = dPhi_l_b;
         dPhi_l_b = fabs(TVector2::Phi_mpi_pi(subleadingMu_p4.Phi() - bjet_p4.Phi()));
         if ( dPhi_l_b < minDPhi_l_b ) minDPhi_l_b = dPhi_l_b;
 
@@ -1582,9 +1582,6 @@ int ScanChain(TChain *ch, double genEventSumw, TString year, TString process) {
 	}
 
       }
-      float dPhi_ll_MET = fabs(TVector2::Phi_mpi_pi(selectedPair_p4.Phi() - puppimet_phi));
-      if ( !(usePuppiMET) )
-	dPhi_ll_MET = fabs(TVector2::Phi_mpi_pi(selectedPair_p4.Phi() - pfmet_phi));
 
       // Add histos: sel8
       plot_names.push_back("nbtagDeepFlavB");

--- a/cpp/ScanChain_Zp.C
+++ b/cpp/ScanChain_Zp.C
@@ -864,9 +864,10 @@ int ScanChain(TChain *ch, double genEventSumw, TString year, TString process) {
 	    for ( unsigned int i=0; i < nt.nJet(); i++ ) {
 	      if ( nt.Jet_pt().at(i) < HEM_jetPtCut )
 		break;
+	      // For jets, increase affected area by half of jet cone (i.e., by 0.2)
 	      if ( nt.Jet_jetId().at(i) > 0 &&
-		   nt.Jet_eta().at(i) > HEM_region[0] && nt.Jet_eta().at(i) < HEM_region[1] &&
-		   nt.Jet_phi().at(i) > HEM_region[2] && nt.Jet_phi().at(i) < HEM_region[3] ) {
+		   nt.Jet_eta().at(i) > HEM_region[0]-0.2 && nt.Jet_eta().at(i) < HEM_region[1]+0.2 &&
+		   nt.Jet_phi().at(i) > HEM_region[2]-0.2 && nt.Jet_phi().at(i) < HEM_region[3]+0.2 ) {
 		hasHEMjet = true;
 		break;
 	      }

--- a/python/stack_plots.py
+++ b/python/stack_plots.py
@@ -352,7 +352,7 @@ def draw_plot(sampleDict, plotname, logY=True, logX=False, plotData=False, doRat
         if not args.plotMllSlices and 'inclusive' not in thismll:
             return(0)
     else:
-        if not args.plotMllSlices and ("cutflow" in plotname and "mll" in plotname):
+        if not args.plotMllSlices and ("cutflow" in plotname and "mll" in plotname and "inclusive" not in plotname):
             return(0)
 
     # Get histograms


### PR DESCRIPTION
As per title, plus minor updates.

Without any optimization, signal yield in 2018 is ~10% lower when "full" HEM15/16 veto is applied.
Can relax veto in the future with flags. So far, the veto is disabled by default.
