### PR TITLE
HLT trigger paths fix

### DIFF
--- a/cpp/ScanChain_Zp.C
+++ b/cpp/ScanChain_Zp.C
@@ -1076,8 +1076,13 @@ int ScanChain(TChain *ch, double genEventSumw, TString year, TString process) {
       icutflow++;
 
       // HLT selection
-      if ( (year=="2016nonAPV" || year=="2016APV") && !( nt.HLT_Mu50() || nt.HLT_TkMu50() ) ) continue;
-      if ( (year=="2017" || year=="2018") && !(nt.HLT_Mu50() || nt.HLT_OldMu100() || nt.HLT_TkMu100()) ) continue;
+      if ( (year=="2016nonAPV" || year=="2016APV") &&
+             !( (tree->GetBranch("HLT_Mu50") ? nt.HLT_Mu50() : 0)
+               || (tree->GetBranch("HLT_TkMu50") ? nt.HLT_TkMu50() : 0) ) ) continue;
+      if ( (year=="2017" || year=="2018") &&
+              !( (tree->GetBranch("HLT_Mu50") ? nt.HLT_Mu50() : 0)
+                || (tree->GetBranch("HLT_OldMu100") ? nt.HLT_OldMu100() : 0)
+                || (tree->GetBranch("HLT_TkMu100") ? nt.HLT_TkMu100() : 0) ) ) continue;
 
       // Apply trigger SF:
       if ( isMC && applyTriggerSF )  {


### PR DESCRIPTION
Account for missing `HLT_*` branches in data, before using them. If the branch does not exist, the corresponding flag is set to zero (as if it has not fired).