### PR TITLE
Allow for negative weights

### DIFF
--- a/cpp/ScanChain_Zp.C
+++ b/cpp/ScanChain_Zp.C
@@ -336,7 +336,7 @@ int ScanChain(TChain *ch, double genEventSumw, TString year, TString process, in
 
   // Define RooDataSet's for fit
   RooRealVar mfit("mfit", "mfit", 175.0, 6500.0);
-  RooRealVar roow("roow", "roow", 0.0, 100.0);
+  RooRealVar roow("roow", "roow", -10000.0, 10000.0);
   map<TString, RooDataSet> roods;
   for ( unsigned int imll=0; imll < mllbin.size(); imll++ ) {
     for ( unsigned int inb=0; inb < nbtag.size(); inb++ ) {
@@ -826,7 +826,7 @@ int ScanChain(TChain *ch, double genEventSumw, TString year, TString process, in
 
 
       if ( isMC ) {
-	if(removeSpikes && weight*factor>1e2) continue;
+	if(removeSpikes && fabs(weight*factor)>1e2) continue;
 	if (process=="DYbb") {
 	  int nGluons = 0;
 	  for ( unsigned int p=0; p<nt.nLHEPart(); p++ ) {
@@ -2545,16 +2545,16 @@ int ScanChain(TChain *ch, double genEventSumw, TString year, TString process, in
   if ( removeDataDuplicates && !(isMC) )
     cout << "Number of duplicates found: " << nDuplicates << endl;
 
-  // Avoid histograms with unphysical negative bin content (due to negative GEN weights)
-  map<TString, TH1F*>::iterator it;
-  for ( it = histos.begin(); it != histos.end(); it++ ) {
-    for ( unsigned int b=1; b<(it->second)->GetNbinsX()+1; b++ ) { 
-      if ( (it->second)->GetBinContent(b)<0.0) {
-	(it->second)->SetBinContent(b,0.0);
-	(it->second)->SetBinError(b,0.0);
-      }
-    }
-  }
+  //// Avoid histograms with unphysical negative bin content (due to negative GEN weights)
+  //map<TString, TH1F*>::iterator it;
+  //for ( it = histos.begin(); it != histos.end(); it++ ) {
+  //  for ( unsigned int b=1; b<(it->second)->GetNbinsX()+1; b++ ) {
+  //    if ( (it->second)->GetBinContent(b)<0.0) {
+  //	(it->second)->SetBinContent(b,0.0);
+  //	(it->second)->SetBinError(b,0.0);
+  //    }
+  //  }
+  //}
 
   if ( writeOutYields_BeforeSel ) {
     TString model = ((TObjString *)process.Tokenize("_")->At(0))->String();

--- a/python/compare_plots.py
+++ b/python/compare_plots.py
@@ -87,6 +87,12 @@ def get_plots(sampleDict, plotname):
                         tplot = copy.deepcopy(inFile.Get(plotname))
                     else:
                         tplot.Add(inFile.Get(plotname))
+
+        for b in range(0, tplot.GetNbinsX()+2):
+            if plot.GetBinContent(b)<0.0 or numpy.isnan(tplot.GetBinContent(b)) or not numpy.isfinite(tplot.GetBinContent(b)):
+                tplot.SetBinContent(b,0.0)
+                tplot.SetBinError(b,0.0)
+
         plotDict[gsample] = tplot
     return plotDict
 

--- a/python/stack_plots.py
+++ b/python/stack_plots.py
@@ -374,6 +374,12 @@ def get_plots(sampleDict, plotname):
                         tplot = copy.deepcopy(inFile.Get(plotname))
                     else:
                         tplot.Add(inFile.Get(plotname))
+
+        for b in range(0, tplot.GetNbinsX()+2):
+            if plot.GetBinContent(b)<0.0 or numpy.isnan(tplot.GetBinContent(b)) or not numpy.isfinite(tplot.GetBinContent(b)):
+                tplot.SetBinContent(b,0.0)
+                tplot.SetBinError(b,0.0)
+
         plotDict[gsample] = tplot
 
     return plotDict


### PR DESCRIPTION
Additionally, remove lines to remove negative bins from histograms: this way, `TH1::Integral` will return correct yield.
Bins with negative entries are directly removed in plotting pythons scripts.

